### PR TITLE
Script to generate all go docs 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,5 @@ test-results.json
 *.tfstate.*
 *.tfvars
 
-#
-accounts.yml
+# generated go docs
+docs/go/**

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ GO_BIN_NAME := api
 
 all:
 	@echo "Nothing to run, choose a target."
+
+
 ##############################
 # TESTS
 ##############################
@@ -199,6 +201,12 @@ go-reports: go-report-gh-standards go-report-aws-monthly-costs
 
 go go-all: go-api go-front go-reports
 	@echo "[Go] Built all"
+
+godocs:
+	@echo "-----"
+	@echo "[Go](docs) building docs "
+	@./scripts/go-docs.sh
+	@echo "[Go](docs) done"
 ##############################
 # DEV
 ##############################

--- a/scripts/go-docs.sh
+++ b/scripts/go-docs.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+shopt -s globstar
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+BASE_DIR="${SCRIPT_DIR}/../"
+DOCS_DIR="${BASE_DIR}docs/go/"
+
+
+rm -Rf ${DOCS_DIR}
+mkdir -p ${DOCS_DIR}
+
+for d in $(find . -type f -name '*.go' | sed -r 's|/[^/]+$||' |sort -u); do
+    action="processing"
+    status="✅"
+    # exclude the root and terraform folders
+    if [[ "${d}" != "." && "${d}" != *"terraform"* ]]; then
+        dir="${DOCS_DIR}${d}"
+        mkdir -p ${dir}
+        go doc -all -u ${d} > ${dir}/index.txt || status="❌"
+    else
+        action="skipping"
+        status="⛔"
+    fi
+    printf '%-64s %-15s %-6s\n' "${d}" "${action}" "${status}"
+done

--- a/scripts/go-docs.sh
+++ b/scripts/go-docs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-shopt -s globstar
+
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 BASE_DIR="${SCRIPT_DIR}/../"


### PR DESCRIPTION
Find all .go files within the project, use the directory path of the file to then generate the doc output and write to a `./docs/go` folder path

Add makefile target to run that script