### PR TITLE
Add filtering for and capture github teams

### DIFF
--- a/services/api/aws/cost/monthly/handlers.go
+++ b/services/api/aws/cost/monthly/handlers.go
@@ -81,7 +81,6 @@ func (a *Api[V, F, C, R]) UnitEnvironmentServices(w http.ResponseWriter, r *http
 
 		head := response.NewRow(headingCells...)
 		body := []R{}
-		// body := []*response.Row[*response.Cell]{}
 
 		for _, g := range withinMonths.Group(byAccountService) {
 			rowTotal := 0.0
@@ -277,7 +276,6 @@ func (a *Api[V, F, C, R]) columnTotals(rows []R) (row R) {
 	for _, r := range rows {
 		cells := r.GetAll()
 		for x := headingsCount; x < len(cells); x++ {
-			// fmt.Printf("[%s] [%v]\n", cells[x].GetName(), cells[x].GetValue())
 			totals[x] += cells[x].GetValue().(float64)
 		}
 	}
@@ -314,6 +312,7 @@ func (a *Api[V, F, C, R]) Totals(w http.ResponseWriter, r *http.Request) {
 		// Limit the items in the data store to those within the start & end date range
 		//
 		months := dates.Strings(dates.Months(startDate, endDate), dates.FormatYM)
+		// impliments IStoreFilterFunc
 		inMonthRange := func(item *cost.Cost) bool {
 			return dates.InMonth(item.Date, months)
 		}

--- a/services/api/aws/cost/monthly/handlers_test.go
+++ b/services/api/aws/cost/monthly/handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"opg-reports/internal/testhelpers"
 	"opg-reports/shared/aws/cost"
 	"opg-reports/shared/data"
 	"opg-reports/shared/dates"
@@ -17,8 +18,8 @@ import (
 // so just check status and errors
 func TestServicesApiAwsCostMonthlyHandlerIndex(t *testing.T) {
 
-	fs := testFs()
-	mux := testMux()
+	fs := testhelpers.Fs()
+	mux := testhelpers.Mux()
 	store := data.NewStore[*cost.Cost]()
 	resp := response.NewResponse[response.ICell, response.IRow[response.ICell]]()
 	api := New(store, fs, resp)
@@ -26,7 +27,7 @@ func TestServicesApiAwsCostMonthlyHandlerIndex(t *testing.T) {
 	api.Register(mux)
 
 	route := "/aws/costs/v1/monthly/"
-	w, r := testWRGet(route)
+	w, r := testhelpers.WRGet(route)
 
 	mux.ServeHTTP(w, r)
 
@@ -51,9 +52,9 @@ func TestServicesApiAwsCostMonthlyHandlerIndex(t *testing.T) {
 // triggers the api to get that data.
 // Checks the number of items returned matches expectations
 func TestServicesApiAwsCostMonthlyHandlerTotals(t *testing.T) {
-	fs := testFs()
-	mux := testMux()
-	min, max, df := testDates()
+	fs := testhelpers.Fs()
+	mux := testhelpers.Mux()
+	min, max, df := testhelpers.Dates()
 	overm := time.Date(max.Year()+1, 1, 1, 0, 0, 0, 0, time.UTC)
 	overmx := time.Date(max.Year()+2, 1, 1, 0, 0, 0, 0, time.UTC)
 	store := data.NewStore[*cost.Cost]()
@@ -77,7 +78,7 @@ func TestServicesApiAwsCostMonthlyHandlerTotals(t *testing.T) {
 	api.Register(mux)
 
 	route := fmt.Sprintf("/aws/costs/v1/monthly/%s/%s/", min.Format(dates.FormatYM), max.Format(dates.FormatYM))
-	w, r := testWRGet(route)
+	w, r := testhelpers.WRGet(route)
 	mux.ServeHTTP(w, r)
 
 	str, b := response.Stringify(w.Result())
@@ -94,9 +95,9 @@ func TestServicesApiAwsCostMonthlyHandlerTotals(t *testing.T) {
 }
 
 func TestServicesApiAwsCostMonthlyHandlerUnits(t *testing.T) {
-	fs := testFs()
-	mux := testMux()
-	min, max, df := testDates()
+	fs := testhelpers.Fs()
+	mux := testhelpers.Mux()
+	min, max, df := testhelpers.Dates()
 	// out of bounds
 	overm := time.Date(max.Year()+1, 1, 1, 0, 0, 0, 0, time.UTC)
 	overmx := time.Date(max.Year()+2, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -121,7 +122,7 @@ func TestServicesApiAwsCostMonthlyHandlerUnits(t *testing.T) {
 	api.Register(mux)
 
 	route := fmt.Sprintf("/aws/costs/v1/monthly/%s/%s/units/", min.Format(dates.FormatYM), max.Format(dates.FormatYM))
-	w, r := testWRGet(route)
+	w, r := testhelpers.WRGet(route)
 	mux.ServeHTTP(w, r)
 
 	str, b := response.Stringify(w.Result())
@@ -137,9 +138,9 @@ func TestServicesApiAwsCostMonthlyHandlerUnits(t *testing.T) {
 }
 
 func TestServicesApiAwsCostMonthlyHandlerUnitEnvs(t *testing.T) {
-	fs := testFs()
-	mux := testMux()
-	min, max, df := testDates()
+	fs := testhelpers.Fs()
+	mux := testhelpers.Mux()
+	min, max, df := testhelpers.Dates()
 	// out of bounds
 	overm := time.Date(max.Year()+1, 1, 1, 0, 0, 0, 0, time.UTC)
 	overmx := time.Date(max.Year()+2, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -167,7 +168,7 @@ func TestServicesApiAwsCostMonthlyHandlerUnitEnvs(t *testing.T) {
 	api.Register(mux)
 
 	route := fmt.Sprintf("/aws/costs/v1/monthly/%s/%s/units/envs/", min.Format(dates.FormatYM), max.Format(dates.FormatYM))
-	w, r := testWRGet(route)
+	w, r := testhelpers.WRGet(route)
 	mux.ServeHTTP(w, r)
 
 	str, b := response.Stringify(w.Result())
@@ -182,9 +183,9 @@ func TestServicesApiAwsCostMonthlyHandlerUnitEnvs(t *testing.T) {
 }
 
 func TestServicesApiAwsCostMonthlyHandlerUnitEnvServices(t *testing.T) {
-	fs := testFs()
-	mux := testMux()
-	min, max, df := testDates()
+	fs := testhelpers.Fs()
+	mux := testhelpers.Mux()
+	min, max, df := testhelpers.Dates()
 	// out of bounds
 	overm := time.Date(max.Year()+1, 1, 1, 0, 0, 0, 0, time.UTC)
 	overmx := time.Date(max.Year()+2, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -212,7 +213,7 @@ func TestServicesApiAwsCostMonthlyHandlerUnitEnvServices(t *testing.T) {
 	api.Register(mux)
 
 	route := fmt.Sprintf("/aws/costs/v1/monthly/%s/%s/units/envs/services/", min.Format(dates.FormatYM), max.Format(dates.FormatYM))
-	w, r := testWRGet(route)
+	w, r := testhelpers.WRGet(route)
 	mux.ServeHTTP(w, r)
 
 	str, b := response.Stringify(w.Result())

--- a/services/api/github/standards/filter.go
+++ b/services/api/github/standards/filter.go
@@ -7,26 +7,69 @@ import (
 	"opg-reports/shared/data"
 	"opg-reports/shared/github/std"
 	"strconv"
+	"strings"
 )
 
+// AllowedGetParameters allows this data to be filtered by
+// - archived
+// - teams
+func (a *Api[V, F, C, R]) AllowedGetParameters() []string {
+	return []string{
+		"archived",
+		"teams",
+	}
+}
+
+// FiltersForGetParameters generates a series of filters to pass into the data store .Filter method based on GET parameters.
+// - Find the allowed get parameters and their values from the current http.Request
+// - If `archived` or `teams` are present in the filter values then add filters functions for those
+//
+// Archived filter is as simple match against the boolean
+//   - `?archived=true`
+//   - `?archived=false`
+//
+// Teams filter checks if any of the passed teams match any of the set values. For OR logic, pass multiple `team` parameters
+// for AND logic pass mutiple teams in one team parameter:
+//   - `?teams=<TEAM-A>&teams=<OR-TEAM-B>`
+//   - `?teams=<TEAM-A>,<AND-TEAM-B>&team=<OR-TEAM-C>`
 func (a *Api[V, F, C, R]) FiltersForGetParameters(r *http.Request) (filters []data.IStoreFilterFunc[*std.Repository]) {
 	slog.Info("filtering based on get parameters")
+	// check what get parameters are found that are allowed
 	filters = []data.IStoreFilterFunc[*std.Repository]{}
 	filterValues := a.GetParameters(a.AllowedGetParameters(), r)
 	slog.Info("filtering based on get parameters",
 		slog.String("filterValues", fmt.Sprintf("%+v", filterValues)),
 	)
+
 	// if archived is set, then check if the item status matches the
 	// value we are looking for
 	if values, ok := filterValues["archived"]; ok {
 
 		status := false
+		// check the last value of the archived get parameter
 		if s, err := strconv.ParseBool(values[len(values)-1]); err == nil {
 			status = s
 		}
-		slog.Info("found archived filter", slog.Bool("status", status))
+		slog.Info("adding filter for archived check", slog.Bool("wanted value", status))
 		filters = append(filters, func(item *std.Repository) bool {
 			return item.Archived == status
+		})
+	}
+
+	// if teams is set, then see if any of the teams on the item matches any of the teams passed
+	if teams, ok := filterValues["teams"]; ok {
+		slog.Info("adding filter for teams check", slog.String("wanted one of", fmt.Sprintf("%+v", teams)))
+
+		filters = append(filters, func(item *std.Repository) bool {
+			mergedTeams := strings.ToLower(strings.Join(item.Teams, ","))
+			found := false
+			for _, s := range teams {
+				if strings.Contains(mergedTeams, strings.ToLower(s)) {
+					found = true
+					break
+				}
+			}
+			return found
 		})
 	}
 

--- a/services/api/github/standards/filter.go
+++ b/services/api/github/standards/filter.go
@@ -1,0 +1,34 @@
+package standards
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"opg-reports/shared/data"
+	"opg-reports/shared/github/std"
+	"strconv"
+)
+
+func (a *Api[V, F, C, R]) FiltersForGetParameters(r *http.Request) (filters []data.IStoreFilterFunc[*std.Repository]) {
+	slog.Info("filtering based on get parameters")
+	filters = []data.IStoreFilterFunc[*std.Repository]{}
+	filterValues := a.GetParameters(a.AllowedGetParameters(), r)
+	slog.Info("filtering based on get parameters",
+		slog.String("filterValues", fmt.Sprintf("%+v", filterValues)),
+	)
+	// if archived is set, then check if the item status matches the
+	// value we are looking for
+	if values, ok := filterValues["archived"]; ok {
+
+		status := false
+		if s, err := strconv.ParseBool(values[len(values)-1]); err == nil {
+			status = s
+		}
+		slog.Info("found archived filter", slog.Bool("status", status))
+		filters = append(filters, func(item *std.Repository) bool {
+			return item.Archived == status
+		})
+	}
+
+	return
+}

--- a/services/api/github/standards/filter_test.go
+++ b/services/api/github/standards/filter_test.go
@@ -1,0 +1,63 @@
+package standards
+
+import (
+	"fmt"
+	"net/http"
+	"opg-reports/internal/testhelpers"
+	"opg-reports/shared/data"
+	"opg-reports/shared/github/std"
+	"opg-reports/shared/server/response"
+	"testing"
+)
+
+func TestServicesApiGithubStandardsFilter(t *testing.T) {
+	fs := testhelpers.Fs()
+	mux := testhelpers.Mux()
+
+	store := data.NewStore[*std.Repository]()
+	l := 90
+	x := 5
+
+	for i := 0; i < l; i++ {
+		c := std.FakeCompliant(nil, std.DefaultBaselineCompliance)
+		c.Archived = false
+		store.Add(c)
+	}
+	for i := 0; i < x; i++ {
+		c := std.Fake(nil)
+		c.Archived = true
+		store.Add(c)
+	}
+
+	resp := response.NewResponse[response.ICell, response.IRow[response.ICell]]()
+	api := New(store, fs, resp)
+	api.Register(mux)
+
+	route := "/github/standards/v1/list/?archived=true"
+	w, r := testhelpers.WRGet(route)
+	mux.ServeHTTP(w, r)
+
+	str, b := response.Stringify(w.Result())
+	res := response.NewResponse[*response.Cell, *response.Row[*response.Cell]]()
+	err := response.FromJson(b, res)
+
+	if err != nil {
+		t.Errorf("failed to parse response: %v", err)
+	}
+	if res.GetStatus() != http.StatusOK {
+		t.Errorf("status code failed")
+		fmt.Println(str)
+	}
+
+	// convert the row back to a repo
+	repos := []*std.Repository{}
+	for _, row := range res.GetData().GetTableBody() {
+		rep := data.FromRow[*std.Repository](row)
+		repos = append(repos, rep)
+	}
+
+	if len(repos) != x {
+		t.Errorf("archive filter failed")
+	}
+
+}

--- a/services/api/github/standards/filter_test.go
+++ b/services/api/github/standards/filter_test.go
@@ -10,22 +10,29 @@ import (
 	"testing"
 )
 
-func TestServicesApiGithubStandardsFilter(t *testing.T) {
+func TestServicesApiGithubStandardsFiltersForGetParameters(t *testing.T) {
+	// --- SETUP
 	fs := testhelpers.Fs()
 	mux := testhelpers.Mux()
-
 	store := data.NewStore[*std.Repository]()
-	l := 90
-	x := 5
+	fakes := 90
+	archived := 5
+	teams := 3
 
-	for i := 0; i < l; i++ {
-		c := std.FakeCompliant(nil, std.DefaultBaselineCompliance)
+	for i := 0; i < fakes; i++ {
+		c := std.Fake(nil)
 		c.Archived = false
 		store.Add(c)
 	}
-	for i := 0; i < x; i++ {
+	for i := 0; i < archived; i++ {
 		c := std.Fake(nil)
 		c.Archived = true
+		store.Add(c)
+	}
+	for i := 0; i < teams; i++ {
+		c := std.Fake(nil)
+		c.Archived = false
+		c.Teams = []string{"ABC", "foo"}
 		store.Add(c)
 	}
 
@@ -33,6 +40,7 @@ func TestServicesApiGithubStandardsFilter(t *testing.T) {
 	api := New(store, fs, resp)
 	api.Register(mux)
 
+	// --- TEST ARCHIVED ONLY VALUES
 	route := "/github/standards/v1/list/?archived=true"
 	w, r := testhelpers.WRGet(route)
 	mux.ServeHTTP(w, r)
@@ -50,14 +58,84 @@ func TestServicesApiGithubStandardsFilter(t *testing.T) {
 	}
 
 	// convert the row back to a repo
-	repos := []*std.Repository{}
-	for _, row := range res.GetData().GetTableBody() {
-		rep := data.FromRow[*std.Repository](row)
-		repos = append(repos, rep)
+	repos := data.FromRows[*std.Repository](res.GetData().GetTableBody())
+
+	if len(repos) != archived {
+		t.Errorf("archive filter failed")
 	}
 
-	if len(repos) != x {
-		t.Errorf("archive filter failed")
+	// --- TEST TEAM FILTER OR LOGIC
+	route = "/github/standards/v1/list/?teams=ABC&team=bar"
+	w, r = testhelpers.WRGet(route)
+	mux.ServeHTTP(w, r)
+
+	str, b = response.Stringify(w.Result())
+	res = response.NewResponse[*response.Cell, *response.Row[*response.Cell]]()
+	err = response.FromJson(b, res)
+
+	if err != nil {
+		t.Errorf("failed to parse response: %v", err)
+	}
+	if res.GetStatus() != http.StatusOK {
+		t.Errorf("status code failed")
+		fmt.Println(str)
+	}
+
+	// convert the row back to a repo
+	repos = data.FromRows[*std.Repository](res.GetData().GetTableBody())
+
+	if len(repos) != teams {
+		t.Errorf("team filter failed")
+	}
+
+	// --- TEST TEAM FILTER AND LOGIC
+	// this should return empty set as that team does not exist
+	route = "/github/standards/v1/list/?teams=ABC,bar"
+	w, r = testhelpers.WRGet(route)
+	mux.ServeHTTP(w, r)
+
+	str, b = response.Stringify(w.Result())
+	res = response.NewResponse[*response.Cell, *response.Row[*response.Cell]]()
+	err = response.FromJson(b, res)
+
+	if err != nil {
+		t.Errorf("failed to parse response: %v", err)
+	}
+	if res.GetStatus() != http.StatusOK {
+		t.Errorf("status code failed")
+		fmt.Println(str)
+	}
+
+	// convert the row back to a repo
+	repos = data.FromRows[*std.Repository](res.GetData().GetTableBody())
+
+	if len(repos) != 0 {
+		t.Errorf("team AND filter failed")
+	}
+
+	// --- TEST TEAM FILTER AND OR COMBINED LOGIC
+	// this should return all expected teams due to the foo team
+	route = "/github/standards/v1/list/?teams=ABC,bar&teams=foo"
+	w, r = testhelpers.WRGet(route)
+	mux.ServeHTTP(w, r)
+
+	str, b = response.Stringify(w.Result())
+	res = response.NewResponse[*response.Cell, *response.Row[*response.Cell]]()
+	err = response.FromJson(b, res)
+
+	if err != nil {
+		t.Errorf("failed to parse response: %v", err)
+	}
+	if res.GetStatus() != http.StatusOK {
+		t.Errorf("status code failed")
+		fmt.Println(str)
+	}
+
+	// convert the row back to a repo
+	repos = data.FromRows[*std.Repository](res.GetData().GetTableBody())
+
+	if len(repos) != teams {
+		t.Errorf("team AND OR filter failed")
 	}
 
 }

--- a/services/api/github/standards/handlers.go
+++ b/services/api/github/standards/handlers.go
@@ -3,11 +3,11 @@ package standards
 import (
 	"net/http"
 	"opg-reports/shared/data"
-	"opg-reports/shared/github/std"
 	"opg-reports/shared/server/response"
 	"sort"
 )
 
+// List: /github/standards/v1/list/
 func (a *Api[V, F, C, R]) List(w http.ResponseWriter, r *http.Request) {
 	a.Start(w, r)
 	resp := a.GetResponse()
@@ -15,15 +15,14 @@ func (a *Api[V, F, C, R]) List(w http.ResponseWriter, r *http.Request) {
 
 	errs := resp.GetError()
 	if len(errs) == 0 {
-		activeOnly := func(item *std.Repository) bool {
-			return item.Archived == false
-		}
 
-		// get everything in range
-		onlyActive := store.Filter(activeOnly)
+		getFilters := a.FiltersForGetParameters(r)
+		if len(getFilters) > 0 {
+			store = store.Filter(getFilters...)
+		}
 		rows := []R{}
 
-		list := onlyActive.List()
+		list := store.List()
 		sort.Slice(list, func(i, j int) bool {
 			return list[i].FullName < list[j].FullName
 		})

--- a/services/api/github/standards/standards.go
+++ b/services/api/github/standards/standards.go
@@ -19,16 +19,6 @@ func (a *Api[V, F, C, R]) Register(mux *http.ServeMux) {
 		server.Middleware(a.List, server.LoggingMW, server.SecurityHeadersMW))
 }
 
-// AllowedGetParameters allows this data to be filtered by
-// - archived
-// - teams
-func (a *Api[V, F, C, R]) AllowedGetParameters() []string {
-	return []string{
-		"archived",
-		"teams",
-	}
-}
-
 func New[V *std.Repository, F files.IReadFS, C response.ICell, R response.IRow[C]](
 	store data.IStore[*std.Repository],
 	fileSys F,

--- a/services/api/github/standards/standards.go
+++ b/services/api/github/standards/standards.go
@@ -9,6 +9,7 @@ import (
 	"opg-reports/shared/server/response"
 )
 
+// Api implements IApi
 type Api[V *std.Repository, F files.IReadFS, C response.ICell, R response.IRow[C]] struct {
 	*server.Api[*std.Repository, F, C, R]
 }
@@ -16,6 +17,16 @@ type Api[V *std.Repository, F files.IReadFS, C response.ICell, R response.IRow[C
 func (a *Api[V, F, C, R]) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/github/standards/{version}/list/{$}",
 		server.Middleware(a.List, server.LoggingMW, server.SecurityHeadersMW))
+}
+
+// AllowedGetParameters allows this data to be filtered by
+// - archived
+// - teams
+func (a *Api[V, F, C, R]) AllowedGetParameters() []string {
+	return []string{
+		"archived",
+		"teams",
+	}
 }
 
 func New[V *std.Repository, F files.IReadFS, C response.ICell, R response.IRow[C]](
@@ -27,35 +38,3 @@ func New[V *std.Repository, F files.IReadFS, C response.ICell, R response.IRow[C
 	return &Api[*std.Repository, F, C, R]{Api: api}
 
 }
-
-// // Api is a concreate version
-// type Api[V *std.Repository, F files.WriteFS] struct {
-// 	store *data.Store[*std.Repository]
-// 	fs    *files.WriteFS
-// }
-
-// func (a *Api[V, F]) Store() data.IStore[*std.Repository] {
-// 	return a.store
-// }
-
-// func (a *Api[V, F]) FS() files.IWriteFS {
-// 	return a.fs
-// }
-
-// func (a *Api[V, F]) Register(mux *http.ServeMux) {
-
-// }
-
-// func (a *Api[V, F]) Write(w http.ResponseWriter, status int, content []byte) {
-// 	w.WriteHeader(status)
-// 	w.Write(content)
-// }
-
-// func New[V *std.Repository, F files.WriteFS](store *data.Store[*std.Repository], fS *files.WriteFS) *Api[V, F] {
-
-// 	return &Api[V, F]{
-// 		store: store,
-// 		fs:    fS,
-// 	}
-
-// }

--- a/services/api/github/standards/standards_test.go
+++ b/services/api/github/standards/standards_test.go
@@ -1,0 +1,39 @@
+package standards
+
+import (
+	"net/http"
+	"opg-reports/internal/testhelpers"
+	"opg-reports/shared/data"
+	"opg-reports/shared/github/std"
+	"opg-reports/shared/server/response"
+	"testing"
+)
+
+func TestServicesApiGithubStandardsStatusCode(t *testing.T) {
+
+	fs := testhelpers.Fs()
+
+	mux := testhelpers.Mux()
+	store := data.NewStore[*std.Repository]()
+	store.Add(std.Fake(nil))
+	resp := response.NewResponse[response.ICell, response.IRow[response.ICell]]()
+	api := New(store, fs, resp)
+	api.Register(mux)
+
+	routes := map[string]int{
+		"/github/standards/v1/list/":               http.StatusOK,
+		"/github/standards/v1/list/?archived=true": http.StatusOK,
+		"/github/standards/v1/list/?teams=foobar":  http.StatusOK,
+		"/github/standards/v1/list":                http.StatusMovedPermanently,
+		"/github/standards/v1/list?archived=true":  http.StatusMovedPermanently,
+	}
+	for route, status := range routes {
+		w, r := testhelpers.WRGet(route)
+		mux.ServeHTTP(w, r)
+		if w.Result().StatusCode != status {
+			r, _ := response.Stringify(w.Result())
+			t.Errorf("http status mismtach [%s] expected [%d], actual [%v]\n---\n%+v\n---\n", route, status, w.Result().StatusCode, r)
+		}
+	}
+
+}

--- a/services/front/config.complex.json
+++ b/services/front/config.complex.json
@@ -21,7 +21,7 @@
                             "name": "Repository Standards",
                             "href": "/github/repository-standards/",
                             "api": {
-                                "list": "/github/standards/v1/list/"
+                                "list": "/github/standards/v1/list/?archived=false"
                             },
                             "template": "dynamic-github-standards-list"
                         }

--- a/services/front/config.complex.json
+++ b/services/front/config.complex.json
@@ -15,6 +15,7 @@
                 {
                     "name": "GitHub",
                     "href": "/github/",
+                    "template": "static-github-home",
                     "header": true,
                     "sections": [
                         {
@@ -30,6 +31,7 @@
                 {
                     "name": "AWS Costs",
                     "href": "/costs/aws/",
+                    "template": "static-aws-costs-home",
                     "header": true,
                     "sections": [
                         {
@@ -65,18 +67,8 @@
                             "template": "dynamic-aws-costs-units-envs-services"
                         }
                     ]
-                },
-                {
-                    "name": "Uptime & Incidents",
-                    "href": "/uptime-incidents/",
-                    "header": true,
-                    "sections": [
-                        {
-                            "name": "Service uptime",
-                            "href": "/uptime-incidents/uptime/"
-                        }
-                    ]
                 }
+
             ]
         }
 

--- a/services/front/config.json
+++ b/services/front/config.json
@@ -6,7 +6,7 @@
             "href": "/",
             "header": true,
             "api": {
-                "list": "/github/standards/v1/list/"
+                "list": "/github/standards/v1/list/?archived=false"
             },
             "template": "dynamic-github-standards-list"
         }

--- a/services/front/config.simple.json
+++ b/services/front/config.simple.json
@@ -6,7 +6,7 @@
             "href": "/",
             "header": true,
             "api": {
-                "list": "/github/standards/v1/list/"
+                "list": "/github/standards/v1/list/?archived=false"
             },
             "template": "dynamic-github-standards-list"
         }

--- a/services/front/server/dynamic_handlers.go
+++ b/services/front/server/dynamic_handlers.go
@@ -40,6 +40,9 @@ func (s *FrontWebServer) Dynamic(w http.ResponseWriter, r *http.Request) {
 	for apiResultName, apiUrl := range urls {
 		// Call API!
 		u := Url(s.ApiScheme, s.ApiAddr, apiUrl)
+		slog.Info("calling api",
+			slog.String("url", u.String()),
+			slog.String("apiUrl", apiUrl))
 		apiResp, err := s.handleApiCall(u)
 		// no error from the api, and no error from parsing the api resposne
 		// into local data, then set to the data map ready for the template parsing
@@ -50,7 +53,7 @@ func (s *FrontWebServer) Dynamic(w http.ResponseWriter, r *http.Request) {
 					if usePrefix {
 						key = fmt.Sprintf("%s_%s", apiResultName, key)
 					}
-					slog.Info("setting api res data", slog.String("key", key))
+					slog.Debug("setting api res data", slog.String("key", key))
 					data[key] = val
 
 				}

--- a/services/front/server/dynamic_handlers.go
+++ b/services/front/server/dynamic_handlers.go
@@ -145,6 +145,6 @@ func (s *FrontWebServer) parseResponse(apiResp *http.Response) (data map[string]
 
 func (s *FrontWebServer) handleApiCall(u *url.URL) (apiResp *http.Response, err error) {
 	// call the api
-	slog.Info("calling api", slog.String("url", u.String()))
+	slog.Info("handle api call", slog.String("url", u.String()))
 	return GetUrl(u.String())
 }

--- a/services/front/server/dynamic_handlers_test.go
+++ b/services/front/server/dynamic_handlers_test.go
@@ -40,7 +40,7 @@ func TestFrontServerDynamicHandlerMockedTotals(t *testing.T) {
 	templates := tmpl.Files(f, tDir)
 
 	route := "/costs/aws/totals/"
-	conf, _ := cnf.Load([]byte(testRealisticServerCnf))
+	conf, _ := cnf.Load(testRealServerCnf())
 	// create new
 	s := New(conf, templates, "", "")
 	// point the totals route to look at the test api
@@ -76,7 +76,7 @@ func TestFrontServerDynamicHandlerMockedUnits(t *testing.T) {
 	templates := tmpl.Files(f, tDir)
 
 	route := "/costs/aws/units/"
-	conf, _ := cnf.Load([]byte(testRealisticServerCnf))
+	conf, _ := cnf.Load(testRealServerCnf())
 	// create new
 	s := New(conf, templates, "", "")
 	// point the totals route to look at the test api

--- a/services/front/server/get.go
+++ b/services/front/server/get.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -17,25 +19,54 @@ func GetUrl(url string) (resp *http.Response, err error) {
 	return
 }
 
-func Url(scheme string, host string, path string) *url.URL {
+func Url(scheme string, host string, path string) (u *url.URL) {
+	slog.Debug("generating url",
+		slog.String("scheme", scheme),
+		slog.String("host", host),
+		slog.String("path", path))
+
+	// set defaults
 	if scheme == "" {
 		scheme = "http"
 	}
-	if host != "" && host[0:1] == ":" {
-		host = "localhost" + host
-	}
-	host = strings.ReplaceAll(host, "http://", "")
-	host = strings.ReplaceAll(host, "https://", "")
+	scheme = strings.ReplaceAll(scheme, "://", "")
 
-	if path[len(path)-1:] != "/" {
-		path = path + "/"
+	parsedHost := host
+	if host == "" {
+		parsedHost = "localhost"
+	} else if host[0:1] == ":" {
+		parsedHost = "localhost" + parsedHost
 	}
-	path = strings.ReplaceAll(path, "http://", "")
+
+	parsedHost = strings.ReplaceAll(parsedHost, "https://", "")
+	parsedHost = strings.ReplaceAll(parsedHost, "http://", "")
+
 	path = strings.ReplaceAll(path, "https://", "")
+	path = strings.ReplaceAll(path, "http://", "")
+	path = strings.ReplaceAll(path, host, "")
+	path = strings.ReplaceAll(path, parsedHost, "")
 
-	return &url.URL{
-		Scheme: scheme,
-		Host:   host,
-		Path:   path,
+	raw := fmt.Sprintf("%s://%s%s", scheme, parsedHost, path)
+	u, err := url.Parse(raw)
+
+	// add trialing slash to the end of the path
+	p := u.Path
+	last := p[len(p)-1:]
+	if err == nil && last != "/" {
+		u.Path = p + "/"
 	}
+
+	slog.Debug("generated url",
+		slog.String("scheme", scheme),
+		slog.String("host", host),
+		slog.String("parsedHost", parsedHost),
+		slog.String("path", path),
+		slog.String("raw", raw),
+		slog.String("u", u.String()))
+
+	if err != nil {
+		return nil
+	}
+	return
+
 }

--- a/services/front/server/get_test.go
+++ b/services/front/server/get_test.go
@@ -20,10 +20,28 @@ func TestFrontServerGetApiMockedDetails(t *testing.T) {
 
 func TestFrontServerGetFromApiGetUrl(t *testing.T) {
 
-	u := Url("", ":8081", "/aws/costs/v1/monthly")
+	u := Url("", ":8081", "/home?test=1&team=1&group=test")
 	str := u.String()
+	if str != "http://localhost:8081/home/?test=1&team=1&group=test" {
+		t.Errorf("url mapping failed: %v", str)
+	}
+
+	u = Url("https://", "", "/home/test/?team=1&group=test")
+	str = u.String()
+	if str != "https://localhost/home/test/?team=1&group=test" {
+		t.Errorf("url mapping failed: %v", str)
+	}
+
+	u = Url("https://", "localhost", "https://localhost/home/test?team=1&group=test")
+	str = u.String()
+	if str != "https://localhost/home/test/?team=1&group=test" {
+		t.Errorf("url mapping failed: %v", str)
+	}
+
+	u = Url("", ":8081", "/aws/costs/v1/monthly")
+	str = u.String()
 	if str != "http://localhost:8081/aws/costs/v1/monthly/" {
-		t.Errorf("url mapping failed")
+		t.Errorf("url mapping failed: %v", str)
 	}
 
 }

--- a/services/front/server/navigation_test.go
+++ b/services/front/server/navigation_test.go
@@ -5,119 +5,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"opg-reports/services/front/cnf"
+	"os"
 	"testing"
 )
 
-const testRealisticServerCnf string = `{
-    "organisation": "OPG",
-    "sections": [
-        {
-            "name": "Home",
-            "href": "/",
-            "exclude": true,
-            "template": "static-home"
-        },
-        {
-            "name": "Costs",
-            "template": "static-costs-home",
-            "href": "/costs/",
-            "sections": [
-                {
-                    "name": "AWS Costs",
-                    "href": "/costs/aws/",
-                    "header": true,
-                    "sections": [
-                        {
-                            "name": "Totals",
-                            "href": "/costs/aws/totals/",
-                            "api": {
-                               "totals": "/aws/costs/{apiVersion}/monthly/{startYM}/{endYM}/"
-                            },
-                            "template": "dynamic-aws-costs-totals"
-                        },
-                        {
-                            "name": "By Unit",
-                            "href": "/costs/aws/units/",
-                            "api": {
-                               "units": "/aws/costs/{apiVersion}/monthly/{startYM}/{endYM}/units/"
-                            },
-                            "template": "dynamic-aws-costs-units"
-                        },
-                        {
-                            "name": "By Unit & Env",
-                            "href": "/costs/aws/units-envs/",
-                            "api": {
-                               "units-envs": "/aws/costs/{apiVersion}/monthly/{startYM}/{endYM}/units/envs/"
-                            },
-                            "template": "dynamic-aws-costs-units-envs"
-                        },
-                        {
-                            "name": "Detailed",
-                            "href": "/costs/aws/detailed/",
-                            "api": {
-                               "detailed": "/aws/costs/{apiVersion}/monthly/{startYM}/{endYM}/units/envs/services/"
-                            },
-                            "template": "dynamic-aws-costs-units-envs-services"
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "name": "Standards",
-            "template": "static-standards-home",
-            "href": "/standards/",
-            "sections": [
-                {
-                    "name": "GitHub Standards",
-                    "href": "/standards/github/",
-                    "header": true,
-                    "sections": [
-                        {
-                            "name": "Repositories",
-                            "href": "/standards/github/repositories/",
-                            "api": "/github/standards/{apiVersion}/list/",
-                            "template": "dynamic-github-standards-list"
-                        }
-                    ]
-                }
-            ]
-        }
-    ],
-    "standards": {
-        "repository": {
-            "baseline": [
-                "has_default_branch_of_main",
-                "has_license",
-                "has_issues",
-                "has_description",
-                "has_rules_enforced_for_admins",
-                "has_pull_request_approval_required"
-            ],
-            "extended": [
-                "has_code_owner_approval_required",
-                "has_readme",
-                "has_code_of_conduct",
-                "has_contributing_guide"
-            ],
-            "information": [
-                "archived",
-                "default_branch",
-                "has_delete_branch_on_merge",
-                "has_pages",
-                "has_downloads",
-                "has_discussions",
-                "has_wiki",
-                "forks",
-                "webhooks",
-                "open_pull_requests",
-                "clone_traffic",
-                "is_private"
-            ]
-        }
-    }
+func testRealServerCnf() []byte {
+	s, _ := os.ReadFile("../config.json")
+	return s
 }
-`
+
 const testServerCfg string = `{
 	"organisation": "test-org",
 	"sections": [

--- a/services/front/server/navigation_test.go
+++ b/services/front/server/navigation_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func testRealServerCnf() []byte {
-	s, _ := os.ReadFile("../config.json")
+	s, _ := os.ReadFile("../config.complex.json")
 	return s
 }
 

--- a/services/front/server/static_handler_test.go
+++ b/services/front/server/static_handler_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 	th "opg-reports/internal/testhelpers"
 	"opg-reports/services/front/cnf"
@@ -19,23 +20,37 @@ func TestFrontServerStaticHandler(t *testing.T) {
 	templates := tmpl.Files(f, tDir)
 
 	mux := th.Mux()
-	conf, _ := cnf.Load([]byte(testRealisticServerCnf))
+	conf, _ := cnf.Load(testRealServerCnf())
 	s := New(conf, templates, "", "")
 	s.Register(mux)
 
-	route := "/costs/"
-	w, r := th.WRGet(route)
-
-	mux.ServeHTTP(w, r)
-
-	if w.Result().StatusCode != http.StatusOK {
-		t.Errorf("should return 200")
+	// --- TEST KNOWN TOP LEVEL STATIC ROUTES
+	routes := []string{}
+	for _, sect := range conf.Sections {
+		if len(sect.Api) == 0 {
+			routes = append(routes, sect.Href)
+		}
+		for _, s := range sect.Sections {
+			if len(s.Api) == 0 {
+				routes = append(routes, s.Href)
+			}
+		}
 	}
 
-	str, _ := response.Stringify(w.Result())
+	for _, route := range routes {
+		w, r := th.WRGet(route)
+		mux.ServeHTTP(w, r)
 
-	if !strings.Contains(str, "OPG Report") {
-		t.Errorf("org not rendered")
+		if w.Result().StatusCode != http.StatusOK {
+			t.Errorf("should return 200: %v", w.Result().StatusCode)
+		}
+
+		str, _ := response.Stringify(w.Result())
+		if !strings.Contains(str, "OPG") {
+			fmt.Println(str)
+			t.Errorf("org not rendered for route [%s]", route)
+
+		}
 	}
 
 }

--- a/services/front/templates/pages/static/aws/aws-home.gotmpl
+++ b/services/front/templates/pages/static/aws/aws-home.gotmpl
@@ -1,0 +1,8 @@
+{{ define "static-aws-home" }}
+    {{ template "head" . }}
+
+    <h1 class="govuk-heading-l">AWS</h1>
+
+    {{ template "foot" . }}
+
+{{ end }}

--- a/services/front/templates/pages/static/aws/costs/costs-home.gotmpl
+++ b/services/front/templates/pages/static/aws/costs/costs-home.gotmpl
@@ -1,0 +1,8 @@
+{{ define "static-aws-costs-home" }}
+    {{ template "head" . }}
+
+    <h1 class="govuk-heading-l">AWS Costs</h1>
+
+    {{ template "foot" . }}
+
+{{ end }}

--- a/services/front/templates/pages/static/costs/costs-home.gotmpl
+++ b/services/front/templates/pages/static/costs/costs-home.gotmpl
@@ -1,8 +1,0 @@
-{{ define "static-costs-home" }}
-    {{ template "head" . }}
-
-    <h1 class="govuk-heading-l">Costs</h1>
-
-    {{ template "foot" . }}
-
-{{ end }}

--- a/services/front/templates/pages/static/github/github-home.gotmpl
+++ b/services/front/templates/pages/static/github/github-home.gotmpl
@@ -1,0 +1,8 @@
+{{ define "static-github-home" }}
+    {{ template "head" . }}
+
+    <h1 class="govuk-heading-l">GitHub</h1>
+
+    {{ template "foot" . }}
+
+{{ end }}

--- a/services/front/templates/pages/static/github/standards/standards-home.gotmpl
+++ b/services/front/templates/pages/static/github/standards/standards-home.gotmpl
@@ -1,4 +1,4 @@
-{{ define "static-standards-home" }}
+{{ define "static-github-standards-home" }}
     {{ template "head" . }}
 
     <h1 class="govuk-heading-l">Standards</h1>

--- a/shared/data/entry.go
+++ b/shared/data/entry.go
@@ -119,3 +119,12 @@ func FromRow[T IEntry](row *response.Row[*response.Cell]) (item T) {
 	item, _ = FromMap[T](mapped)
 	return
 }
+
+func FromRows[T IEntry](rows []*response.Row[*response.Cell]) (items []T) {
+	items = []T{}
+	for _, row := range rows {
+		item := FromRow[T](row)
+		items = append(items, item)
+	}
+	return
+}

--- a/shared/github/std/fake.go
+++ b/shared/github/std/fake.go
@@ -93,7 +93,12 @@ func Fake(c *Repository) (f *Repository) {
 	c.HasPullRequestApprovalRequired = fake.Choice[bool]([]bool{true, false})
 	c.HasVulnerabilityAlerts = fake.Choice[bool]([]bool{true, false})
 
-	c.Teams = []string{}
+	// slices
+	x := fake.Int(1, 5)
+	for i := 0; i < x; i++ {
+		c.Teams = append(c.Teams, fake.String(12))
+	}
+
 	f = c
 	slog.Debug("[aws/cost] fake", slog.String("UID", f.UID()))
 	return

--- a/shared/github/std/fake.go
+++ b/shared/github/std/fake.go
@@ -93,6 +93,7 @@ func Fake(c *Repository) (f *Repository) {
 	c.HasPullRequestApprovalRequired = fake.Choice[bool]([]bool{true, false})
 	c.HasVulnerabilityAlerts = fake.Choice[bool]([]bool{true, false})
 
+	c.Teams = []string{}
 	f = c
 	slog.Debug("[aws/cost] fake", slog.String("UID", f.UID()))
 	return

--- a/shared/github/std/std.go
+++ b/shared/github/std/std.go
@@ -59,6 +59,7 @@ type Repository struct {
 	Name           string    `json:"name"`
 	Owner          string    `json:"owner"`
 	LastCommitDate time.Time `json:"last_commit_date"`
+	Teams          []string  `json:"teams"`
 
 	CountClones       int `json:"clone_traffic"`
 	CountForks        int `json:"forks"`
@@ -188,6 +189,12 @@ func (c *Repository) dataViaClient(client *github.Client) {
 	// webhooks
 	if hooks, _, err := client.Repositories.ListHooks(context.Background(), c.Owner, c.Name, &github.ListOptions{PerPage: 100}); err == nil {
 		c.CountWebhooks = len(hooks)
+	}
+	// teams
+	if teams, _, err := client.Repositories.ListTeams(context.Background(), c.Owner, c.Name, &github.ListOptions{PerPage: 100}); err == nil {
+		for _, team := range teams {
+			c.Teams = append(c.Teams, *team.Name)
+		}
 	}
 }
 

--- a/shared/github/std/std.go
+++ b/shared/github/std/std.go
@@ -15,7 +15,7 @@ const readmePath string = "./README.md"
 const codeOfConductPath string = "./CODE_OF_CONDUCT.md"
 const contributingGuidePath string = "./CONTRIBUTING.md"
 
-var defaultBaselineCompliance = []string{
+var DefaultBaselineCompliance = []string{
 	"has_default_branch_of_main",
 	"has_license",
 	"has_issues",
@@ -23,13 +23,13 @@ var defaultBaselineCompliance = []string{
 	"has_rules_enforced_for_admins",
 	"has_pull_request_approval_required",
 }
-var defaultExtendedCompliance = []string{
+var DefaultExtendedCompliance = []string{
 	"has_code_owner_approval_required",
 	"has_readme",
 	"has_code_of_conduct",
 	"has_contributing_guide",
 }
-var defaultInformation = []string{
+var DefaultInformation = []string{
 	"archived",
 	"branch_name",
 	"has_delete_branch_on_merge",
@@ -59,7 +59,7 @@ type Repository struct {
 	Name           string    `json:"name"`
 	Owner          string    `json:"owner"`
 	LastCommitDate time.Time `json:"last_commit_date"`
-	Teams          []string  `json:"teams"`
+	Teams          []string  `json:"teams,omitempty"`
 
 	CountClones       int `json:"clone_traffic"`
 	CountForks        int `json:"forks"`

--- a/shared/github/std/std_test.go
+++ b/shared/github/std/std_test.go
@@ -19,19 +19,19 @@ func TestSharedGithubStandardsRealData(t *testing.T) {
 		r, _ := repos.Get(ctx, client, owner, testRepo)
 
 		com := NewWithR(nil, r, client)
-		if comply, _, _ := com.Compliant(defaultBaselineCompliance); comply != true {
+		if comply, _, _ := com.Compliant(DefaultBaselineCompliance); comply != true {
 			t.Errorf("error with compliance")
 		}
 	}
 }
 func TestSharedGithubStandardsComply(t *testing.T) {
-	c := FakeCompliant(nil, defaultBaselineCompliance)
-	if comply, _, _ := c.Compliant(defaultBaselineCompliance); !comply {
+	c := FakeCompliant(nil, DefaultBaselineCompliance)
+	if comply, _, _ := c.Compliant(DefaultBaselineCompliance); !comply {
 		t.Errorf("compliance failed")
 	}
 
-	c = FakeCompliant(nil, defaultExtendedCompliance)
-	if comply, _, _ := c.Compliant(defaultExtendedCompliance); !comply {
+	c = FakeCompliant(nil, DefaultExtendedCompliance)
+	if comply, _, _ := c.Compliant(DefaultExtendedCompliance); !comply {
 		t.Errorf("compliance failed")
 	}
 

--- a/shared/server/server_test.go
+++ b/shared/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"opg-reports/internal/testhelpers"
 	"opg-reports/shared/data"
 	"opg-reports/shared/files"
 	"opg-reports/shared/server/response"
@@ -45,5 +46,27 @@ func TestSharedServerApi(t *testing.T) {
 
 	if tApi.GetResponse() != resp {
 		t.Errorf("response mismatch")
+	}
+}
+
+func TestSharedServerApiGetParams(t *testing.T) {
+	td := os.TempDir()
+	tDir, _ := os.MkdirTemp(td, "server-test-*")
+	defer os.RemoveAll(tDir)
+	dfSys := os.DirFS(tDir).(files.IReadFS)
+
+	f := files.NewFS(dfSys, tDir)
+	store := data.NewStore[*tEntry]()
+	resp := response.NewResponse[response.ICell, response.IRow[response.ICell]]()
+
+	tApi := NewApi(store, f, resp)
+	_, r := testhelpers.WRGet("/test/?team=dev&team=ops&not-allowed=1")
+
+	v := tApi.GetParameters([]string{"team"}, r)
+	if len(v) != 1 {
+		t.Errorf("get param logic failed: %v ", v)
+	}
+	if _, ok := v["team"]; !ok {
+		t.Errorf("get param logic failed: %v ", v)
 	}
 }


### PR DESCRIPTION
Change the api end point for github to allow the acrhive status check to be handled by get parameters.

- Add new interface for api to handle allowed get parameters and fetching their values from the http.Request
- Add default concreate versions to the base server.Api
- Update github api to implement the allow parameters methof so can filter by archived

We will want to filter repos by team names for team overview pages

- capture the team data in the data fetching
- include random teams in faker call
- update the filters to allow teams

Other bits

- add tests for filtering on github standards nad simple tests to check endpoint respond
- bug fixes for url parsing
- update tests to use the shared testhelper versions