### PR TITLE
Filtering for aws api endpoint

### DIFF
--- a/services/api/aws/cost/monthly/filter.go
+++ b/services/api/aws/cost/monthly/filter.go
@@ -1,0 +1,71 @@
+package monthly
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"opg-reports/shared/aws/cost"
+	"opg-reports/shared/data"
+	"strings"
+)
+
+// AllowedGetParameters allows this data to be filtered by
+// - teams
+func (a *Api[V, F, C, R]) AllowedGetParameters() []string {
+	return []string{
+		"unit",
+		"environment",
+	}
+}
+
+// FiltersForGetParameters generates a series of filters to pass into the data store .Filter method based on GET parameters.
+func (a *Api[V, F, C, R]) FiltersForGetParameters(r *http.Request) (filters []data.IStoreFilterFunc[*cost.Cost]) {
+	slog.Info("filtering based on get parameters")
+	// check what get parameters are found that are allowed
+	filters = []data.IStoreFilterFunc[*cost.Cost]{}
+	filterValues := a.GetParameters(a.AllowedGetParameters(), r)
+	slog.Info("filtering based on get parameters",
+		slog.String("filterValues", fmt.Sprintf("%+v", filterValues)),
+	)
+
+	if len(filterValues) > 0 {
+		resp := a.GetResponse()
+		resp.SetMetadata("filters", filterValues)
+	}
+
+	// if unit is passed, check all of then against the account unit details
+	if units, ok := filterValues["unit"]; ok {
+		slog.Info("adding filter for unit check", slog.String("wanted one of", fmt.Sprintf("%+v", units)))
+
+		filters = append(filters, func(item *cost.Cost) bool {
+			check := strings.ToLower(item.AccountUnit)
+			found := false
+			for _, u := range units {
+				if check == strings.ToLower(u) {
+					found = true
+					break
+				}
+			}
+			return found
+		})
+	}
+
+	// if environment is passed, check all of then against the account environemt
+	if environments, ok := filterValues["environment"]; ok {
+		slog.Info("adding filter for environment check", slog.String("wanted one of", fmt.Sprintf("%+v", environments)))
+
+		filters = append(filters, func(item *cost.Cost) bool {
+			check := strings.ToLower(item.AccountEnvironment)
+			found := false
+			for _, e := range environments {
+				if check == strings.ToLower(e) {
+					found = true
+					break
+				}
+			}
+			return found
+		})
+	}
+
+	return
+}

--- a/services/api/aws/cost/monthly/handlers.go
+++ b/services/api/aws/cost/monthly/handlers.go
@@ -33,6 +33,11 @@ func (a *Api[V, F, C, R]) MonthlyCostsPerAccountUnitEnvironmentAndServices(w htt
 		inMonthRange := func(c *cost.Cost) bool {
 			return dates.InMonth(c.Date, months)
 		}
+		// Add get filters to the data
+		getFilters := a.FiltersForGetParameters(r)
+		if len(getFilters) > 0 {
+			store = store.Filter(getFilters...)
+		}
 		withinMonths := store.Filter(inMonthRange)
 
 		// Add table headings
@@ -108,6 +113,11 @@ func (a *Api[V, F, C, R]) MonthlyCostsPerAccountUnitAndEnvironments(w http.Respo
 		inMonthRange := func(item *cost.Cost) bool {
 			return dates.InMonth(item.Date, months)
 		}
+		// Add get filters to the data
+		getFilters := a.FiltersForGetParameters(r)
+		if len(getFilters) > 0 {
+			store = store.Filter(getFilters...)
+		}
 		withinMonths := store.Filter(inMonthRange)
 		// Add table headings
 		headingCells := []C{
@@ -178,6 +188,11 @@ func (a *Api[V, F, C, R]) MonthlyCostsPerAccountUnits(w http.ResponseWriter, r *
 		months := dates.Strings(dates.Months(startDate, endDate), dates.FormatYM)
 		inMonthRange := func(item *cost.Cost) bool {
 			return dates.InMonth(item.Date, months)
+		}
+		// Add get filters to the data
+		getFilters := a.FiltersForGetParameters(r)
+		if len(getFilters) > 0 {
+			store = store.Filter(getFilters...)
 		}
 
 		withinMonths := store.Filter(inMonthRange)

--- a/services/api/aws/cost/monthly/handlers.go
+++ b/services/api/aws/cost/monthly/handlers.go
@@ -4,41 +4,9 @@ import (
 	"log/slog"
 	"net/http"
 	"opg-reports/shared/aws/cost"
-	"opg-reports/shared/data"
 	"opg-reports/shared/dates"
 	"opg-reports/shared/server/response"
-	"strings"
 )
-
-// Filters
-var excludeTax = func(item *cost.Cost) bool {
-	return strings.ToLower(item.Service) != "tax"
-}
-
-// Helpers used within grouping
-var unit = func(i *cost.Cost) (string, string) {
-	return "account_unit", strings.ToLower(i.AccountUnit)
-}
-var account_id = func(i *cost.Cost) (string, string) {
-	return "account_id", i.AccountId
-}
-var account_env = func(i *cost.Cost) (string, string) {
-	return "account_environment", strings.ToLower(i.AccountEnvironment)
-}
-var service = func(i *cost.Cost) (string, string) {
-	return "service", strings.ToLower(i.Service)
-}
-
-// Group by month
-var byUnit = func(item *cost.Cost) string {
-	return data.ToIdxF(item, unit)
-}
-var byUnitEnv = func(item *cost.Cost) string {
-	return data.ToIdxF(item, unit, account_env)
-}
-var byAccountService = func(item *cost.Cost) string {
-	return data.ToIdxF(item, account_id, unit, account_env, service)
-}
 
 // Index: /aws/costs/v1/monthly
 func (a *Api[V, F, C, R]) Index(w http.ResponseWriter, r *http.Request) {
@@ -47,9 +15,9 @@ func (a *Api[V, F, C, R]) Index(w http.ResponseWriter, r *http.Request) {
 
 }
 
-// Unit, Env & Service costs: /aws/costs/{version}/monthly/{start}/{end}/units/envs/services/{$}
+// MonthlyCostsPerAccountUnitEnvironmentAndServices: /aws/costs/{version}/monthly/{start}/{end}/units/envs/services/{$}
 // Previously "Detailed breakdown" sheet
-func (a *Api[V, F, C, R]) UnitEnvironmentServices(w http.ResponseWriter, r *http.Request) {
+func (a *Api[V, F, C, R]) MonthlyCostsPerAccountUnitEnvironmentAndServices(w http.ResponseWriter, r *http.Request) {
 	a.Start(w, r)
 	resp := a.GetResponse()
 	store := a.Store()
@@ -124,9 +92,9 @@ func (a *Api[V, F, C, R]) UnitEnvironmentServices(w http.ResponseWriter, r *http
 
 }
 
-// Unit & Env costs: /aws/costs/{version}/monthly/{start}/{end}/units/envs/{$}
+// MonthlyCostsPerAccountUnitAndEnvironments: /aws/costs/{version}/monthly/{start}/{end}/units/envs/{$}
 // Previously "Service And Environment" sheet
-func (a *Api[V, F, C, R]) UnitEnvironments(w http.ResponseWriter, r *http.Request) {
+func (a *Api[V, F, C, R]) MonthlyCostsPerAccountUnitAndEnvironments(w http.ResponseWriter, r *http.Request) {
 	a.Start(w, r)
 	resp := a.GetResponse()
 	store := a.Store()
@@ -194,9 +162,9 @@ func (a *Api[V, F, C, R]) UnitEnvironments(w http.ResponseWriter, r *http.Reques
 
 }
 
-// Unit costs: /aws/costs/{version}/monthly/{start}/{end}/units/{$}
+// MonthlyCostsPerAccountUnits: /aws/costs/{version}/monthly/{start}/{end}/units/{$}
 // Previously "Service" sheet
-func (a *Api[V, F, C, R]) Units(w http.ResponseWriter, r *http.Request) {
+func (a *Api[V, F, C, R]) MonthlyCostsPerAccountUnits(w http.ResponseWriter, r *http.Request) {
 	a.Start(w, r)
 	resp := a.GetResponse()
 	store := a.Store()
@@ -211,6 +179,7 @@ func (a *Api[V, F, C, R]) Units(w http.ResponseWriter, r *http.Request) {
 		inMonthRange := func(item *cost.Cost) bool {
 			return dates.InMonth(item.Date, months)
 		}
+
 		withinMonths := store.Filter(inMonthRange)
 		// Add table headings
 		headingCells := []C{
@@ -260,44 +229,11 @@ func (a *Api[V, F, C, R]) Units(w http.ResponseWriter, r *http.Request) {
 
 }
 
-// columnTotals creates a row whose cell values are the total for that column
-func (a *Api[V, F, C, R]) columnTotals(rows []R) (row R) {
-	var totals []float64
-	row = response.NewRow[C]().(R)
-	headingsCount := 0
-	if len(rows) > 0 {
-		totals = make([]float64, rows[0].GetTotalCellCount())
-		for i := 0; i < rows[0].GetTotalCellCount(); i++ {
-			totals[i] = 0.0
-		}
-		headingsCount = rows[0].GetHeadersCount()
-	}
-
-	for _, r := range rows {
-		cells := r.GetAll()
-		for x := headingsCount; x < len(cells); x++ {
-			totals[x] += cells[x].GetValue().(float64)
-		}
-	}
-
-	for i, total := range totals {
-		var c C
-		if i < headingsCount {
-			c = response.NewCellHeader("Total", total).(C)
-		} else {
-			c = response.NewCell("Total", total).(C)
-		}
-
-		row.SetRaw(c)
-	}
-	return
-}
-
-// Totals: /aws/costs/{version}/monthly/{start}/{end}/{$}
+// MonthlyTotals: /aws/costs/{version}/monthly/{start}/{end}/{$}
 // Returns cost data split into with & without tax segments, then grouped by the month
 // Previously "Totals" sheet
 // Note: if {start} or {end} are "-" it uses current month
-func (a *Api[V, F, C, R]) Totals(w http.ResponseWriter, r *http.Request) {
+func (a *Api[V, F, C, R]) MonthlyTotals(w http.ResponseWriter, r *http.Request) {
 	slog.Info("[api/aws/costs/monthly] totals", slog.String("uri", r.RequestURI))
 	a.Start(w, r)
 	resp := a.GetResponse()
@@ -315,6 +251,11 @@ func (a *Api[V, F, C, R]) Totals(w http.ResponseWriter, r *http.Request) {
 		// impliments IStoreFilterFunc
 		inMonthRange := func(item *cost.Cost) bool {
 			return dates.InMonth(item.Date, months)
+		}
+		// Add get filters to the data
+		getFilters := a.FiltersForGetParameters(r)
+		if len(getFilters) > 0 {
+			store = store.Filter(getFilters...)
 		}
 		// Add table headings
 		headingCells := []C{
@@ -344,41 +285,4 @@ func (a *Api[V, F, C, R]) Totals(w http.ResponseWriter, r *http.Request) {
 		resp.SetData(table)
 	}
 	a.End(w, r)
-}
-
-func withoutTaxR(withoutTax data.IStore[*cost.Cost], months []string) response.IRow[response.ICell] {
-	rowTotal := 0.0
-	withoutTaxCells := []response.ICell{
-		response.NewCellHeader("Excluded", "Excluded"),
-	}
-	for _, m := range months {
-		inM := func(item *cost.Cost) bool {
-			return dates.InMonth(item.Date, []string{m})
-		}
-		values := withoutTax.Filter(inM)
-		total := cost.Total(values.List())
-		rowTotal += total
-		cell := response.NewCell(m, total)
-		withoutTaxCells = append(withoutTaxCells, cell)
-	}
-	withoutTaxCells = append(withoutTaxCells, response.NewCellExtra("Totals", rowTotal))
-	return response.NewRow(withoutTaxCells...)
-}
-func withTaxR(withTax data.IStore[*cost.Cost], months []string) response.IRow[response.ICell] {
-	rowTotal := 0.0
-	withTaxCells := []response.ICell{
-		response.NewCellHeader("Included", "Included"),
-	}
-	for _, m := range months {
-		inM := func(item *cost.Cost) bool {
-			return dates.InMonth(item.Date, []string{m})
-		}
-		values := withTax.Filter(inM)
-		total := cost.Total(values.List())
-		rowTotal += total
-		cell := response.NewCell(m, total)
-		withTaxCells = append(withTaxCells, cell)
-	}
-	withTaxCells = append(withTaxCells, response.NewCellExtra("Totals", rowTotal))
-	return response.NewRow(withTaxCells...)
 }

--- a/services/api/aws/cost/monthly/handlers_test.go
+++ b/services/api/aws/cost/monthly/handlers_test.go
@@ -9,6 +9,7 @@ import (
 	"opg-reports/shared/data"
 	"opg-reports/shared/dates"
 	"opg-reports/shared/fake"
+	"opg-reports/shared/logger"
 	"opg-reports/shared/server/response"
 	"testing"
 	"time"
@@ -20,7 +21,7 @@ import (
 // Index is empty and returns simple api response without a result
 // so just check status and errors
 func TestServicesApiAwsCostMonthlyHandlerIndex(t *testing.T) {
-
+	logger.LogSetup()
 	fs := testhelpers.Fs()
 	mux := testhelpers.Mux()
 	store := data.NewStore[*cost.Cost]()
@@ -61,6 +62,7 @@ func TestServicesApiAwsCostMonthlyHandlerIndex(t *testing.T) {
 // URLS:
 //   - /aws/costs/v1/monthly/%s/%s/
 func TestServicesApiAwsCostMonthlyHandlerTotals(t *testing.T) {
+	logger.LogSetup()
 	p := message.NewPrinter(language.English)
 	fs := testhelpers.Fs()
 	mux := testhelpers.Mux()
@@ -175,6 +177,7 @@ func TestServicesApiAwsCostMonthlyHandlerTotals(t *testing.T) {
 }
 
 func TestServicesApiAwsCostMonthlyHandlerUnits(t *testing.T) {
+	logger.LogSetup()
 	fs := testhelpers.Fs()
 	mux := testhelpers.Mux()
 	min, max, df := testhelpers.Dates()
@@ -218,6 +221,7 @@ func TestServicesApiAwsCostMonthlyHandlerUnits(t *testing.T) {
 }
 
 func TestServicesApiAwsCostMonthlyHandlerUnitEnvs(t *testing.T) {
+	logger.LogSetup()
 	fs := testhelpers.Fs()
 	mux := testhelpers.Mux()
 	min, max, df := testhelpers.Dates()
@@ -263,6 +267,7 @@ func TestServicesApiAwsCostMonthlyHandlerUnitEnvs(t *testing.T) {
 }
 
 func TestServicesApiAwsCostMonthlyHandlerUnitEnvServices(t *testing.T) {
+	logger.LogSetup()
 	fs := testhelpers.Fs()
 	mux := testhelpers.Mux()
 	min, max, df := testhelpers.Dates()

--- a/services/api/aws/cost/monthly/handlers_test.go
+++ b/services/api/aws/cost/monthly/handlers_test.go
@@ -127,8 +127,6 @@ func TestServicesApiAwsCostMonthlyHandlerTotals(t *testing.T) {
 		fmt.Println(str)
 	}
 
-	fmt.Println(allTotal)
-
 	apiTotal := 0.0
 	for _, row := range res.GetData().GetTableBody() {
 		if row.HeaderCells[0].Name == "Included" {
@@ -136,8 +134,8 @@ func TestServicesApiAwsCostMonthlyHandlerTotals(t *testing.T) {
 		}
 	}
 	// round the values down
-	apiTotalS := p.Sprintf("$%.5f", apiTotal)
-	unitTotalS := p.Sprintf("$%.5f", unitTotal)
+	apiTotalS := p.Sprintf("$%.4f", apiTotal)
+	unitTotalS := p.Sprintf("$%.4f", unitTotal)
 	if apiTotalS != unitTotalS {
 		t.Errorf("filtering by unit failed: expected [%v] actual [%v]", unitTotal, apiTotal)
 	}
@@ -168,8 +166,8 @@ func TestServicesApiAwsCostMonthlyHandlerTotals(t *testing.T) {
 		}
 	}
 	// round the values down
-	apiTotalS = p.Sprintf("$%.5f", apiTotal)
-	allTotalS := p.Sprintf("$%.5f", allTotal)
+	apiTotalS = p.Sprintf("$%.4f", apiTotal)
+	allTotalS := p.Sprintf("$%.4f", allTotal)
 	if apiTotalS != allTotalS {
 		t.Errorf("filtering by unit failed: expected [%v] actual [%v]", allTotal, apiTotal)
 	}

--- a/services/api/aws/cost/monthly/lambdas.go
+++ b/services/api/aws/cost/monthly/lambdas.go
@@ -1,0 +1,37 @@
+package monthly
+
+import (
+	"opg-reports/shared/aws/cost"
+	"opg-reports/shared/data"
+	"strings"
+)
+
+// Filters
+var excludeTax = func(item *cost.Cost) bool {
+	return strings.ToLower(item.Service) != "tax"
+}
+
+// Helpers used within grouping
+var unit = func(i *cost.Cost) (string, string) {
+	return "account_unit", strings.ToLower(i.AccountUnit)
+}
+var account_id = func(i *cost.Cost) (string, string) {
+	return "account_id", i.AccountId
+}
+var account_env = func(i *cost.Cost) (string, string) {
+	return "account_environment", strings.ToLower(i.AccountEnvironment)
+}
+var service = func(i *cost.Cost) (string, string) {
+	return "service", strings.ToLower(i.Service)
+}
+
+// Group by month
+var byUnit = func(item *cost.Cost) string {
+	return data.ToIdxF(item, unit)
+}
+var byUnitEnv = func(item *cost.Cost) string {
+	return data.ToIdxF(item, unit, account_env)
+}
+var byAccountService = func(item *cost.Cost) string {
+	return data.ToIdxF(item, account_id, unit, account_env, service)
+}

--- a/services/api/aws/cost/monthly/monthly.go
+++ b/services/api/aws/cost/monthly/monthly.go
@@ -20,13 +20,13 @@ func (a *Api[V, F, C, R]) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/aws/costs/{version}/monthly/{$}",
 		server.Middleware(a.Index, server.LoggingMW, server.SecurityHeadersMW))
 	mux.HandleFunc("/aws/costs/{version}/monthly/{start}/{end}/{$}",
-		server.Middleware(a.Totals, server.LoggingMW, server.SecurityHeadersMW))
+		server.Middleware(a.MonthlyTotals, server.LoggingMW, server.SecurityHeadersMW))
 	mux.HandleFunc("/aws/costs/{version}/monthly/{start}/{end}/units/{$}",
-		server.Middleware(a.Units, server.LoggingMW, server.SecurityHeadersMW))
+		server.Middleware(a.MonthlyCostsPerAccountUnits, server.LoggingMW, server.SecurityHeadersMW))
 	mux.HandleFunc("/aws/costs/{version}/monthly/{start}/{end}/units/envs/{$}",
-		server.Middleware(a.UnitEnvironments, server.LoggingMW, server.SecurityHeadersMW))
+		server.Middleware(a.MonthlyCostsPerAccountUnitAndEnvironments, server.LoggingMW, server.SecurityHeadersMW))
 	mux.HandleFunc("/aws/costs/{version}/monthly/{start}/{end}/units/envs/services/{$}",
-		server.Middleware(a.UnitEnvironmentServices, server.LoggingMW, server.SecurityHeadersMW))
+		server.Middleware(a.MonthlyCostsPerAccountUnitEnvironmentAndServices, server.LoggingMW, server.SecurityHeadersMW))
 }
 
 func (a *Api[V, F, C, R]) startAndEndDates(r *http.Request) (startDate time.Time, endDate time.Time) {

--- a/services/api/aws/cost/monthly/monthly_test.go
+++ b/services/api/aws/cost/monthly/monthly_test.go
@@ -5,12 +5,13 @@ import (
 	"opg-reports/internal/testhelpers"
 	"opg-reports/shared/aws/cost"
 	"opg-reports/shared/data"
+	"opg-reports/shared/logger"
 	"opg-reports/shared/server/response"
 	"testing"
 )
 
 func TestServicesApiAwsCostMonthlyStatusCode(t *testing.T) {
-
+	logger.LogSetup()
 	fs := testhelpers.Fs()
 
 	mux := testhelpers.Mux()
@@ -44,6 +45,7 @@ func TestServicesApiAwsCostMonthlyStatusCode(t *testing.T) {
 }
 
 func TestServicesApiAwsCostMonthlyFSMatch(t *testing.T) {
+	logger.LogSetup()
 	fs := testhelpers.Fs()
 	store := data.NewStore[*cost.Cost]()
 	resp := response.NewResponse[response.ICell, response.IRow[response.ICell]]()
@@ -56,6 +58,7 @@ func TestServicesApiAwsCostMonthlyFSMatch(t *testing.T) {
 }
 
 func TestServicesApiAwsCostMonthlyStoreMatch(t *testing.T) {
+	logger.LogSetup()
 	fs := testhelpers.Fs()
 	min, max, df := testhelpers.Dates()
 	store := data.NewStore[*cost.Cost]()

--- a/services/api/aws/cost/monthly/tax.go
+++ b/services/api/aws/cost/monthly/tax.go
@@ -1,0 +1,46 @@
+package monthly
+
+import (
+	"opg-reports/shared/aws/cost"
+	"opg-reports/shared/data"
+	"opg-reports/shared/dates"
+	"opg-reports/shared/server/response"
+)
+
+func withoutTaxR(withoutTax data.IStore[*cost.Cost], months []string) response.IRow[response.ICell] {
+	rowTotal := 0.0
+	withoutTaxCells := []response.ICell{
+		response.NewCellHeader("Excluded", "Excluded"),
+	}
+	for _, m := range months {
+		inM := func(item *cost.Cost) bool {
+			return dates.InMonth(item.Date, []string{m})
+		}
+		values := withoutTax.Filter(inM)
+		total := cost.Total(values.List())
+		rowTotal += total
+		cell := response.NewCell(m, total)
+		withoutTaxCells = append(withoutTaxCells, cell)
+	}
+	withoutTaxCells = append(withoutTaxCells, response.NewCellExtra("Totals", rowTotal))
+	return response.NewRow(withoutTaxCells...)
+}
+
+func withTaxR(withTax data.IStore[*cost.Cost], months []string) response.IRow[response.ICell] {
+	rowTotal := 0.0
+	withTaxCells := []response.ICell{
+		response.NewCellHeader("Included", "Included"),
+	}
+	for _, m := range months {
+		inM := func(item *cost.Cost) bool {
+			return dates.InMonth(item.Date, []string{m})
+		}
+		values := withTax.Filter(inM)
+		total := cost.Total(values.List())
+		rowTotal += total
+		cell := response.NewCell(m, total)
+		withTaxCells = append(withTaxCells, cell)
+	}
+	withTaxCells = append(withTaxCells, response.NewCellExtra("Totals", rowTotal))
+	return response.NewRow(withTaxCells...)
+}

--- a/services/api/aws/cost/monthly/totals.go
+++ b/services/api/aws/cost/monthly/totals.go
@@ -1,0 +1,36 @@
+package monthly
+
+import "opg-reports/shared/server/response"
+
+// columnTotals creates a row whose cell values are the total for that column
+func (a *Api[V, F, C, R]) columnTotals(rows []R) (row R) {
+	var totals []float64
+	row = response.NewRow[C]().(R)
+	headingsCount := 0
+	if len(rows) > 0 {
+		totals = make([]float64, rows[0].GetTotalCellCount())
+		for i := 0; i < rows[0].GetTotalCellCount(); i++ {
+			totals[i] = 0.0
+		}
+		headingsCount = rows[0].GetHeadersCount()
+	}
+
+	for _, r := range rows {
+		cells := r.GetAll()
+		for x := headingsCount; x < len(cells); x++ {
+			totals[x] += cells[x].GetValue().(float64)
+		}
+	}
+
+	for i, total := range totals {
+		var c C
+		if i < headingsCount {
+			c = response.NewCellHeader("Total", total).(C)
+		} else {
+			c = response.NewCell("Total", total).(C)
+		}
+
+		row.SetRaw(c)
+	}
+	return
+}

--- a/services/api/github/standards/filter.go
+++ b/services/api/github/standards/filter.go
@@ -41,6 +41,11 @@ func (a *Api[V, F, C, R]) FiltersForGetParameters(r *http.Request) (filters []da
 		slog.String("filterValues", fmt.Sprintf("%+v", filterValues)),
 	)
 
+	if len(filterValues) > 0 {
+		resp := a.GetResponse()
+		resp.SetMetadata("filters", filterValues)
+	}
+
 	// if archived is set, then check if the item status matches the
 	// value we are looking for
 	if values, ok := filterValues["archived"]; ok {

--- a/services/api/github/standards/filter_test.go
+++ b/services/api/github/standards/filter_test.go
@@ -6,11 +6,13 @@ import (
 	"opg-reports/internal/testhelpers"
 	"opg-reports/shared/data"
 	"opg-reports/shared/github/std"
+	"opg-reports/shared/logger"
 	"opg-reports/shared/server/response"
 	"testing"
 )
 
 func TestServicesApiGithubStandardsFiltersForGetParameters(t *testing.T) {
+	logger.LogSetup()
 	// --- SETUP
 	fs := testhelpers.Fs()
 	mux := testhelpers.Mux()

--- a/services/api/github/standards/filter_test.go
+++ b/services/api/github/standards/filter_test.go
@@ -52,6 +52,7 @@ func TestServicesApiGithubStandardsFiltersForGetParameters(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to parse response: %v", err)
 	}
+
 	if res.GetStatus() != http.StatusOK {
 		t.Errorf("status code failed")
 		fmt.Println(str)

--- a/services/api/github/standards/filter_test.go
+++ b/services/api/github/standards/filter_test.go
@@ -80,7 +80,7 @@ func TestServicesApiGithubStandardsFiltersForGetParameters(t *testing.T) {
 		t.Errorf("failed to parse response: %v", err)
 	}
 	if res.GetStatus() != http.StatusOK {
-		t.Errorf("status code failed")
+		t.Errorf("status code failed: %v", res.GetStatus())
 		fmt.Println(str)
 	}
 
@@ -88,7 +88,7 @@ func TestServicesApiGithubStandardsFiltersForGetParameters(t *testing.T) {
 	repos = data.FromRows[*std.Repository](res.GetData().GetTableBody())
 
 	if len(repos) != teams {
-		t.Errorf("team filter failed")
+		t.Errorf("team filter failed: actual [%v] expected [%v]", len(repos), teams)
 	}
 
 	// --- TEST TEAM FILTER AND LOGIC

--- a/services/api/github/standards/filter_test.go
+++ b/services/api/github/standards/filter_test.go
@@ -64,7 +64,7 @@ func TestServicesApiGithubStandardsFiltersForGetParameters(t *testing.T) {
 	repos := data.FromRows[*std.Repository](res.GetData().GetTableBody())
 
 	if len(repos) != archived {
-		t.Errorf("archive filter failed")
+		t.Errorf("archive filter failed: expected [%v] actual [%v]", archived, len(repos))
 	}
 
 	// --- TEST TEAM FILTER OR LOGIC

--- a/services/api/github/standards/standards_test.go
+++ b/services/api/github/standards/standards_test.go
@@ -5,12 +5,13 @@ import (
 	"opg-reports/internal/testhelpers"
 	"opg-reports/shared/data"
 	"opg-reports/shared/github/std"
+	"opg-reports/shared/logger"
 	"opg-reports/shared/server/response"
 	"testing"
 )
 
 func TestServicesApiGithubStandardsStatusCode(t *testing.T) {
-
+	logger.LogSetup()
 	fs := testhelpers.Fs()
 
 	mux := testhelpers.Mux()

--- a/services/front/server/dynamic_handlers_test.go
+++ b/services/front/server/dynamic_handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"opg-reports/services/front/cnf"
 	"opg-reports/services/front/tmpl"
 	"opg-reports/shared/files"
+	"opg-reports/shared/logger"
 	"opg-reports/shared/server/response"
 	"os"
 	"strings"
@@ -30,6 +31,7 @@ func (i *testEntry) Valid() bool {
 }
 
 func TestFrontServerDynamicHandlerMockedTotals(t *testing.T) {
+	logger.LogSetup()
 
 	ms := th.MockServer(mockAwsCostMonthlyTotals(), http.StatusOK)
 	defer ms.Close()
@@ -66,6 +68,7 @@ func TestFrontServerDynamicHandlerMockedTotals(t *testing.T) {
 }
 
 func TestFrontServerDynamicHandlerMockedUnits(t *testing.T) {
+	logger.LogSetup()
 	content := mockAwsCostMonthlyUnits()
 	ms := th.MockServer(content, http.StatusOK)
 	defer ms.Close()

--- a/services/front/server/navigation_test.go
+++ b/services/front/server/navigation_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"opg-reports/services/front/cnf"
+	"opg-reports/shared/logger"
 	"os"
 	"testing"
 )
@@ -62,6 +63,7 @@ const testServerCfg string = `{
 }`
 
 func TestFrontServerNavigationTop(t *testing.T) {
+	logger.LogSetup()
 	conf, _ := cnf.Load([]byte(testServerCfg))
 	s := New(conf, nil, "", "")
 
@@ -91,6 +93,7 @@ func TestFrontServerNavigationTop(t *testing.T) {
 }
 
 func TestFrontServerNavigationSide(t *testing.T) {
+	logger.LogSetup()
 	conf, _ := cnf.Load([]byte(testServerCfg))
 	s := New(conf, nil, "", "")
 
@@ -111,6 +114,7 @@ func TestFrontServerNavigationSide(t *testing.T) {
 }
 
 func TestFrontServerNavigationActive(t *testing.T) {
+	logger.LogSetup()
 	conf, _ := cnf.Load([]byte(testServerCfg))
 	s := New(conf, nil, "", "")
 

--- a/services/front/server/routes_test.go
+++ b/services/front/server/routes_test.go
@@ -3,11 +3,12 @@ package server
 import (
 	th "opg-reports/internal/testhelpers"
 	"opg-reports/services/front/cnf"
+	"opg-reports/shared/logger"
 	"testing"
 )
 
 func TestFrontServerRegister(t *testing.T) {
-
+	logger.LogSetup()
 	mux := th.Mux()
 	conf, _ := cnf.Load([]byte(testServerCfg))
 	s := New(conf, nil, "", "")

--- a/services/front/server/static_handler_test.go
+++ b/services/front/server/static_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"opg-reports/services/front/cnf"
 	"opg-reports/services/front/tmpl"
 	"opg-reports/shared/files"
+	"opg-reports/shared/logger"
 	"opg-reports/shared/server/response"
 	"os"
 	"strings"
@@ -14,6 +15,7 @@ import (
 )
 
 func TestFrontServerStaticHandler(t *testing.T) {
+	logger.LogSetup()
 	tDir := "../templates/"
 	dfSys := os.DirFS(tDir).(files.IReadFS)
 	f := files.NewFS(dfSys, tDir)

--- a/shared/aws/cost/cost_test.go
+++ b/shared/aws/cost/cost_test.go
@@ -2,10 +2,12 @@ package cost
 
 import (
 	"opg-reports/shared/data"
+	"opg-reports/shared/logger"
 	"testing"
 )
 
 func TestSharedAwsCostUUID(t *testing.T) {
+	logger.LogSetup()
 	cost := New(nil)
 	if len(cost.UUID) <= 0 {
 		t.Errorf("failed to create uuid")
@@ -23,6 +25,7 @@ func TestSharedAwsCostUUID(t *testing.T) {
 }
 
 func TestSharedAwsCostValid(t *testing.T) {
+	logger.LogSetup()
 	cost := New(nil)
 
 	if cost.Valid() {
@@ -57,6 +60,7 @@ func testIsI[V data.IEntry](i V) bool {
 	return i.UID() != ""
 }
 func TestSharedAwsCostInterface(t *testing.T) {
+	logger.LogSetup()
 	c := &Cost{}
 	if testIsI[*Cost](c) {
 		t.Errorf("should not be nil")

--- a/shared/aws/cost/fake_test.go
+++ b/shared/aws/cost/fake_test.go
@@ -1,11 +1,13 @@
 package cost
 
 import (
+	"opg-reports/shared/logger"
 	"testing"
 	"time"
 )
 
 func TestSharedAwsCostFake(t *testing.T) {
+	logger.LogSetup()
 	max := time.Now().UTC()
 	min := time.Date(max.Year()-2, max.Month(), 1, 0, 0, 0, 0, time.UTC)
 	f := time.RFC3339

--- a/shared/data/entry_test.go
+++ b/shared/data/entry_test.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"fmt"
+	"opg-reports/shared/logger"
 	"testing"
 	"time"
 )
@@ -40,6 +41,7 @@ func (i *testEntryExt) Valid() bool {
 }
 
 func TestSharedDataEntryToRowFromRow(t *testing.T) {
+	logger.LogSetup()
 	test := &testEntryExt{Id: "01", Tag: "tag1", Category: "cat1"}
 	r := ToRowC(test)
 
@@ -57,6 +59,7 @@ func TestSharedDataEntryToRowFromRow(t *testing.T) {
 }
 
 func TestSharedDataEntryComparable(t *testing.T) {
+	logger.LogSetup()
 	t1 := &testEntry{Id: "t1"}
 	t2 := &testEntry{Id: "t2"}
 	t3 := &testEntry{Id: "t1"}
@@ -72,6 +75,7 @@ func TestSharedDataEntryComparable(t *testing.T) {
 }
 
 func TestSharedDataMapConversion(t *testing.T) {
+	logger.LogSetup()
 	indent = false
 
 	te := &testEntry{Id: "001"}

--- a/shared/data/idx_test.go
+++ b/shared/data/idx_test.go
@@ -2,10 +2,12 @@ package data
 
 import (
 	"fmt"
+	"opg-reports/shared/logger"
 	"testing"
 )
 
 func TestSharedDataToIdx(t *testing.T) {
+	logger.LogSetup()
 	i := &testEntryExt{Id: "01", Tag: "test-tag", Category: "cat1"}
 
 	idx := ToIdx(i, "tag", "category")

--- a/shared/data/store_test.go
+++ b/shared/data/store_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"opg-reports/shared/fake"
 	"opg-reports/shared/files"
+	"opg-reports/shared/logger"
 	"os"
 	"strconv"
 	"strings"
@@ -14,6 +15,7 @@ import (
 // by Tag, Category & then both. These are then compared to the counters of
 // each to make sure grouping is working
 func TestSharedDataStoreGroup(t *testing.T) {
+	logger.LogSetup()
 	items := []*testEntryExt{}
 	tags := []string{"t1", "t2", "t3"}
 	cats := []string{"c1", "c2"}
@@ -102,6 +104,7 @@ func TestSharedDataStoreGroup(t *testing.T) {
 }
 
 func TestSharedDataStoreNewFromFS(t *testing.T) {
+	logger.LogSetup()
 	td := os.TempDir()
 	tDir, _ := os.MkdirTemp(td, "test-data-store-fs-*")
 	dfSys := os.DirFS(tDir).(files.IReadFS)
@@ -130,6 +133,7 @@ func TestSharedDataStoreNewFromFS(t *testing.T) {
 }
 
 func BenchmarkSharedDataStoreNewFromFS(b *testing.B) {
+	logger.LogSetup()
 	td := os.TempDir()
 	tDir, _ := os.MkdirTemp(td, "b-data-store-fs-*")
 	dfSys := os.DirFS(tDir).(files.IReadFS)
@@ -153,16 +157,19 @@ func BenchmarkSharedDataStoreNewFromFS(b *testing.B) {
 }
 
 func TestSharedDataStoreNew(t *testing.T) {
+	logger.LogSetup()
 	s := NewStore[*testEntry]()
 	if s.Length() != 0 {
 		t.Errorf("not empty")
 	}
 }
 func BenchmarkSharedDataStoreNew(b *testing.B) {
+	logger.LogSetup()
 	NewStore[*testEntry]()
 }
 
 func TestSharedDataStoreNewFromMap(t *testing.T) {
+	logger.LogSetup()
 	items := map[string]*testEntry{}
 	for i := 0; i < 200; i++ {
 		e := &testEntry{Id: fmt.Sprintf("%d", i+1)}
@@ -175,6 +182,7 @@ func TestSharedDataStoreNewFromMap(t *testing.T) {
 }
 
 func BenchmarkSharedDataStoreNewFromMap(b *testing.B) {
+	logger.LogSetup()
 	items := map[string]*testEntry{}
 	for i := 0; i < 2000; i++ {
 		e := &testEntry{Id: fmt.Sprintf("%d", i+1)}
@@ -185,6 +193,7 @@ func BenchmarkSharedDataStoreNewFromMap(b *testing.B) {
 }
 
 func TestSharedDataStoreNewFromList(t *testing.T) {
+	logger.LogSetup()
 	items := []*testEntry{}
 	for i := 0; i < 200; i++ {
 		items = append(items, &testEntry{Id: fmt.Sprintf("%d", i+1)})
@@ -196,6 +205,7 @@ func TestSharedDataStoreNewFromList(t *testing.T) {
 }
 
 func BenchmarkSharedDataStoreNewFromList(b *testing.B) {
+	logger.LogSetup()
 	items := []*testEntry{}
 	for i := 0; i < 200000; i++ {
 		items = append(items, &testEntry{Id: fmt.Sprintf("%d", i+1)})
@@ -204,6 +214,7 @@ func BenchmarkSharedDataStoreNewFromList(b *testing.B) {
 }
 
 func TestSharedDataStoreAdd(t *testing.T) {
+	logger.LogSetup()
 	store := NewStore[*testEntry]()
 	for i := 0; i < 100; i++ {
 		store.Add(&testEntry{Id: fmt.Sprintf("%d", i+1)})
@@ -214,6 +225,7 @@ func TestSharedDataStoreAdd(t *testing.T) {
 }
 
 func BenchmarkSharedDataStoreAdd(b *testing.B) {
+	logger.LogSetup()
 	store := NewStore[*testEntry]()
 	for i := 0; i < 20000; i++ {
 		store.Add(&testEntry{Id: fmt.Sprintf("%d", i+1)})
@@ -221,6 +233,7 @@ func BenchmarkSharedDataStoreAdd(b *testing.B) {
 }
 
 func TestSharedDataStoreAll(t *testing.T) {
+	logger.LogSetup()
 	store := NewStore[*testEntry]()
 	for i := 0; i < 100; i++ {
 		store.Add(&testEntry{Id: fmt.Sprintf("%d", i+1)})
@@ -237,6 +250,7 @@ func TestSharedDataStoreAll(t *testing.T) {
 }
 
 func BenchmarkSharedDataStoreAll(b *testing.B) {
+	logger.LogSetup()
 	items := []*testEntry{}
 	for i := 0; i < 200000; i++ {
 		items = append(items, &testEntry{Id: fmt.Sprintf("%d", i+1)})
@@ -247,6 +261,7 @@ func BenchmarkSharedDataStoreAll(b *testing.B) {
 }
 
 func TestSharedDataStoreGet(t *testing.T) {
+	logger.LogSetup()
 	store := NewStore[*testEntry]()
 	for i := 0; i < 1000; i++ {
 		store.Add(&testEntry{Id: fmt.Sprintf("%d", i+1)})
@@ -267,6 +282,7 @@ func TestSharedDataStoreGet(t *testing.T) {
 }
 
 func BenchmarkSharedDataStoreGet(b *testing.B) {
+	logger.LogSetup()
 	items := []*testEntry{}
 	for i := 0; i < 200000; i++ {
 		items = append(items, &testEntry{Id: fmt.Sprintf("%d", i+1)})
@@ -277,6 +293,7 @@ func BenchmarkSharedDataStoreGet(b *testing.B) {
 }
 
 func TestSharedDataStoreFilter(t *testing.T) {
+	logger.LogSetup()
 	items := []*testEntry{}
 	for i := 0; i < 40; i++ {
 		items = append(items, &testEntry{Id: fmt.Sprintf("%d", i+1)})
@@ -320,6 +337,7 @@ func TestSharedDataStoreFilter(t *testing.T) {
 }
 
 func BenchmarkSharedDataStoreFilter(b *testing.B) {
+	logger.LogSetup()
 	items := []*testEntry{}
 	for i := 0; i < 200000; i++ {
 		items = append(items, &testEntry{Id: fmt.Sprintf("%d", i+1)})

--- a/shared/dates/dates_test.go
+++ b/shared/dates/dates_test.go
@@ -1,12 +1,13 @@
 package dates
 
 import (
+	"opg-reports/shared/logger"
 	"testing"
 	"time"
 )
 
 func TestSharedDatesGetFormat(t *testing.T) {
-
+	logger.LogSetup()
 	test := time.Now().UTC().Format(Format)
 
 	if GetFormat(test[0:4]) != "2006" || GetFormat(FormatY) != FormatY {
@@ -26,6 +27,7 @@ func TestSharedDatesGetFormat(t *testing.T) {
 }
 
 func TestSharedDatesStringToDate(t *testing.T) {
+	logger.LogSetup()
 	valid := []string{
 		"2024", "2024-01", "2024-02-29", "2024-03-01T00:00",
 	}
@@ -48,6 +50,7 @@ func TestSharedDatesStringToDate(t *testing.T) {
 }
 
 func TestSharedDatesStrings(t *testing.T) {
+	logger.LogSetup()
 	dates := []time.Time{
 		time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
 		time.Date(2023, 9, 1, 0, 0, 0, 0, time.UTC),
@@ -64,7 +67,7 @@ func TestSharedDatesStrings(t *testing.T) {
 }
 
 func TestSharedDatesStringToDateDefault(t *testing.T) {
-
+	logger.LogSetup()
 	ds := time.Now().UTC().Format(FormatYMD)
 
 	d, _ := StringToDateDefault("-", "-", ds)
@@ -75,7 +78,7 @@ func TestSharedDatesStringToDateDefault(t *testing.T) {
 }
 
 func TestSharedDatesReformat(t *testing.T) {
-
+	logger.LogSetup()
 	full := "2024-02-29"
 	expected := "2024-02"
 	actual := Reformat(full, FormatYM)

--- a/shared/dates/range_test.go
+++ b/shared/dates/range_test.go
@@ -1,11 +1,13 @@
 package dates
 
 import (
+	"opg-reports/shared/logger"
 	"testing"
 	"time"
 )
 
 func TestSharedDatesMonths(t *testing.T) {
+	logger.LogSetup()
 	s := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
 	e := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	set := Months(s, e)
@@ -29,6 +31,7 @@ func TestSharedDatesMonths(t *testing.T) {
 }
 
 func TestSharedDatesDays(t *testing.T) {
+	logger.LogSetup()
 	s := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
 	e := time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC)
 	set := Days(s, e)
@@ -38,6 +41,7 @@ func TestSharedDatesDays(t *testing.T) {
 }
 
 func TestSharedDatesInMonth(t *testing.T) {
+	logger.LogSetup()
 	months := []string{"2024-01", "2024-02", "2024-03"}
 
 	d := "2024-02"

--- a/shared/env/env_test.go
+++ b/shared/env/env_test.go
@@ -1,12 +1,13 @@
 package env
 
 import (
+	"opg-reports/shared/logger"
 	"os"
 	"testing"
 )
 
 func TestGet(t *testing.T) {
-
+	logger.LogSetup()
 	if Get("PATH", "123") != os.Getenv("PATH") {
 		t.Errorf("path mismatch")
 	}

--- a/shared/fake/fake_test.go
+++ b/shared/fake/fake_test.go
@@ -1,6 +1,7 @@
 package fake
 
 import (
+	"opg-reports/shared/logger"
 	"slices"
 	"strconv"
 	"strings"
@@ -9,7 +10,7 @@ import (
 )
 
 func TestSharedFakeString(t *testing.T) {
-
+	logger.LogSetup()
 	str := String(5)
 
 	if len(str) != 5 {
@@ -25,6 +26,7 @@ func TestSharedFakeString(t *testing.T) {
 }
 
 func TestSharedFakeInt(t *testing.T) {
+	logger.LogSetup()
 	i := Int(-10, 10)
 	if i > 10 || i < -10 {
 		t.Errorf("int out of range: %d", i)
@@ -32,6 +34,7 @@ func TestSharedFakeInt(t *testing.T) {
 }
 
 func TestSharedFakeIntAsStr(t *testing.T) {
+	logger.LogSetup()
 	is := IntAsStr(-10, 10)
 	i, err := strconv.Atoi(is)
 	if err != nil {
@@ -43,6 +46,7 @@ func TestSharedFakeIntAsStr(t *testing.T) {
 }
 
 func TestSharedFakeFloat(t *testing.T) {
+	logger.LogSetup()
 	f := Float(-2.0, 55.0)
 	if f > 55.0 || f < -2.0 {
 		t.Errorf("float out of range: %v", f)
@@ -50,6 +54,7 @@ func TestSharedFakeFloat(t *testing.T) {
 }
 
 func TestSharedFakeFloatAsStr(t *testing.T) {
+	logger.LogSetup()
 	fs := FloatAsStr(-10.0, 55.0)
 	f, err := strconv.ParseFloat(fs, 10)
 	if err != nil {
@@ -62,6 +67,7 @@ func TestSharedFakeFloatAsStr(t *testing.T) {
 }
 
 func TestSharedFakeDate(t *testing.T) {
+	logger.LogSetup()
 	max := time.Now().UTC()
 	min := time.Date(max.Year()-2, max.Month(), 1, 0, 0, 0, 0, time.UTC)
 
@@ -73,6 +79,7 @@ func TestSharedFakeDate(t *testing.T) {
 }
 
 func TestSharedFakeDateAsStr(t *testing.T) {
+	logger.LogSetup()
 	max := time.Now().UTC()
 	min := time.Date(max.Year()-2, max.Month(), 1, 0, 0, 0, 0, time.UTC)
 	f := time.RFC3339
@@ -88,6 +95,7 @@ func TestSharedFakeDateAsStr(t *testing.T) {
 }
 
 func TestSharedFakeChoices(t *testing.T) {
+	logger.LogSetup()
 	single := []string{"one"}
 	item := Choice(single)
 	if item != single[0] {

--- a/shared/files/files_test.go
+++ b/shared/files/files_test.go
@@ -3,11 +3,13 @@ package files
 import (
 	"embed"
 	"fmt"
+	"opg-reports/shared/logger"
 	"os"
 	"testing"
 )
 
 func TestSharedFilesWriteFileError(t *testing.T) {
+	logger.LogSetup()
 	var err error
 	td := os.TempDir()
 	tDir, _ := os.MkdirTemp(td, "files-write-err-*")
@@ -28,6 +30,7 @@ func TestSharedFilesWriteFileError(t *testing.T) {
 var testFS embed.FS
 
 func TestSharedFilesAllFromEmbedded(t *testing.T) {
+	logger.LogSetup()
 	tDir := "./testdata"
 	fSys := NewFS(testFS, tDir)
 
@@ -48,6 +51,7 @@ func TestSharedFilesAllFromEmbedded(t *testing.T) {
 }
 
 func TestSharedFilesReadFromEmbedded(t *testing.T) {
+	logger.LogSetup()
 	tDir := "testdata"
 	fSys := NewFS(testFS, tDir)
 
@@ -70,6 +74,7 @@ func TestSharedFilesReadFromEmbedded(t *testing.T) {
 }
 
 func TestSharedFilesAllFromDir(t *testing.T) {
+	logger.LogSetup()
 	td := os.TempDir()
 	tDir, _ := os.MkdirTemp(td, "files-all-*")
 	dfSys := os.DirFS(tDir).(IReadFS)
@@ -101,6 +106,7 @@ func TestSharedFilesAllFromDir(t *testing.T) {
 }
 
 func TestSharedFilesWriteReadFromDir(t *testing.T) {
+	logger.LogSetup()
 	td := os.TempDir()
 	tDir, _ := os.MkdirTemp(td, "files-write-read-*")
 	dfSys := os.DirFS(tDir).(IReadFS)

--- a/shared/files/pathfile_test.go
+++ b/shared/files/pathfile_test.go
@@ -2,11 +2,13 @@ package files
 
 import (
 	"io/fs"
+	"opg-reports/shared/logger"
 	"os"
 	"testing"
 )
 
 func TestNewPathFile(t *testing.T) {
+	logger.LogSetup()
 	dir := "testdata"
 	dirFs := os.DirFS(dir)
 	entries, err := fs.ReadDir(dirFs, ".")

--- a/shared/github/std/std_test.go
+++ b/shared/github/std/std_test.go
@@ -5,10 +5,12 @@ import (
 	"opg-reports/shared/env"
 	"opg-reports/shared/github/cl"
 	"opg-reports/shared/github/repos"
+	"opg-reports/shared/logger"
 	"testing"
 )
 
 func TestSharedGithubStandardsRealData(t *testing.T) {
+	logger.LogSetup()
 	owner := "ministryofjustice"
 	testRepo := "opg-incident-response"
 	token := env.Get("GITHUB_ACCESS_TOKEN", "")
@@ -25,6 +27,7 @@ func TestSharedGithubStandardsRealData(t *testing.T) {
 	}
 }
 func TestSharedGithubStandardsComply(t *testing.T) {
+	logger.LogSetup()
 	c := FakeCompliant(nil, DefaultBaselineCompliance)
 	if comply, _, _ := c.Compliant(DefaultBaselineCompliance); !comply {
 		t.Errorf("compliance failed")

--- a/shared/report/arg_test.go
+++ b/shared/report/arg_test.go
@@ -3,12 +3,13 @@ package report
 import (
 	"errors"
 	"opg-reports/shared/dates"
+	"opg-reports/shared/logger"
 	"testing"
 	"time"
 )
 
 func TestSharedReportArgs(t *testing.T) {
-
+	logger.LogSetup()
 	a := &Arg{}
 	a.SetName("foo")
 	if a.GetName() != "foo" {

--- a/shared/report/report_test.go
+++ b/shared/report/report_test.go
@@ -1,10 +1,12 @@
 package report
 
 import (
+	"opg-reports/shared/logger"
 	"testing"
 )
 
 func TestSharedReportOK(t *testing.T) {
+	logger.LogSetup()
 	acc := NewArg("account", false, "account name", "test00")
 	month := NewMonthArg("month", true, "month", "")
 	in := "2024-01"
@@ -42,6 +44,7 @@ func TestSharedReportOK(t *testing.T) {
 }
 
 func TestSharedReportPanics(t *testing.T) {
+	logger.LogSetup()
 	defer func() { _ = recover() }()
 	month := NewMonthArg("fail", true, "month", "")
 	args := []IReportArgument{month}
@@ -53,6 +56,7 @@ func TestSharedReportPanics(t *testing.T) {
 }
 
 func TestSharedReportNew(t *testing.T) {
+	logger.LogSetup()
 	report := New()
 
 	if len(report.GetArguments()) != 0 {

--- a/shared/server/middleware_test.go
+++ b/shared/server/middleware_test.go
@@ -3,11 +3,13 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
+	"opg-reports/shared/logger"
 	"slices"
 	"testing"
 )
 
 func TestMiddlewareDefaultSecurityHeaders(t *testing.T) {
+	logger.LogSetup()
 	r := httptest.NewRequest(http.MethodGet, "/user/", nil)
 
 	rec := httptest.NewRecorder()

--- a/shared/server/response/response_data_test.go
+++ b/shared/server/response/response_data_test.go
@@ -2,10 +2,12 @@ package response
 
 import (
 	"fmt"
+	"opg-reports/shared/logger"
 	"testing"
 )
 
 func TestSharedServerResponseDataTable(t *testing.T) {
+	logger.LogSetup()
 	cells := []ICell{
 		NewCell("name1", "v1"),
 		NewCell("name1.5", "v1.5"),
@@ -38,6 +40,7 @@ func TestSharedServerResponseDataTable(t *testing.T) {
 }
 
 func TestSharedServerResponseDataRowRaw(t *testing.T) {
+	logger.LogSetup()
 	cells := []ICell{
 		NewCell("name1", "v1"),
 		NewCell("name1.5", "v1.5"),
@@ -64,6 +67,7 @@ func TestSharedServerResponseDataRowRaw(t *testing.T) {
 
 }
 func TestSharedServerResponseDataRowSupplementary(t *testing.T) {
+	logger.LogSetup()
 	cells := []ICell{
 		NewCell("name1", "v1"),
 		NewCell("name1.5", "v1.5"),
@@ -81,6 +85,7 @@ func TestSharedServerResponseDataRowSupplementary(t *testing.T) {
 
 }
 func TestSharedServerResponseDataRowData(t *testing.T) {
+	logger.LogSetup()
 	cells := []ICell{
 		NewCell("name1", "v1"),
 		NewCell("name1.5", "v1.5"),
@@ -98,6 +103,7 @@ func TestSharedServerResponseDataRowData(t *testing.T) {
 
 }
 func TestSharedServerResponseDataRowHeaders(t *testing.T) {
+	logger.LogSetup()
 	cells := []ICell{
 		NewCell("name1", "v1"),
 		NewCellHeader("name2", "v2"),
@@ -114,7 +120,7 @@ func TestSharedServerResponseDataRowHeaders(t *testing.T) {
 
 }
 func TestSharedServerResponseDataCellSupplementary(t *testing.T) {
-
+	logger.LogSetup()
 	c1 := NewCell("name1", "v1")
 	c2 := NewCellHeader("name2", "v2")
 	c3 := NewCellExtra("name3", "v3")
@@ -137,7 +143,7 @@ func TestSharedServerResponseDataCellSupplementary(t *testing.T) {
 
 }
 func TestSharedServerResponseDataCellHeader(t *testing.T) {
-
+	logger.LogSetup()
 	c1 := NewCell("name1", "v1")
 	c2 := NewCellHeader("name2", "v2")
 	c3 := NewCellExtra("name3", "v3")
@@ -160,6 +166,7 @@ func TestSharedServerResponseDataCellHeader(t *testing.T) {
 
 }
 func TestSharedServerResponseDataCellValues(t *testing.T) {
+	logger.LogSetup()
 	cells := []ICell{
 		NewCell("name1", "v1"),
 		NewCellHeader("name2", "v2"),
@@ -181,7 +188,7 @@ func TestSharedServerResponseDataCellValues(t *testing.T) {
 }
 
 func TestSharedServerResponseDataCellNames(t *testing.T) {
-
+	logger.LogSetup()
 	cells := []ICell{
 		NewCell("name1", "v1"),
 		NewCellHeader("name2", "v2"),

--- a/shared/server/response/response_test.go
+++ b/shared/server/response/response_test.go
@@ -5,12 +5,14 @@ import (
 	"net/http"
 	"opg-reports/shared/dates"
 	"opg-reports/shared/fake"
+	"opg-reports/shared/logger"
 	"strings"
 	"testing"
 	"time"
 )
 
 func TestSharedServerResponseToJsonFromJson(t *testing.T) {
+	logger.LogSetup()
 	resp := NewResponse[ICell, IRow[ICell]]()
 	tb := FakeTable(3, 2, 5, 1)
 	resp.SetData(tb)
@@ -29,6 +31,7 @@ func TestSharedServerResponseToJsonFromJson(t *testing.T) {
 
 }
 func TestSharedServerResponseRequestData(t *testing.T) {
+	logger.LogSetup()
 	resp := NewResponse[ICell, IRow[ICell]]()
 
 	tb := FakeTable(3, 2, 5, 1)
@@ -59,6 +62,7 @@ func TestSharedServerResponseRequestData(t *testing.T) {
 
 }
 func TestSharedServerResponseRequestErrorAndStatus(t *testing.T) {
+	logger.LogSetup()
 	resp := NewResponse[ICell, IRow[ICell]]()
 	resp.SetErrorAndStatus(fmt.Errorf("error test!"), http.StatusNotExtended)
 
@@ -70,6 +74,7 @@ func TestSharedServerResponseRequestErrorAndStatus(t *testing.T) {
 	}
 }
 func TestSharedServerResponseRequestErrors(t *testing.T) {
+	logger.LogSetup()
 	resp := NewResponse[ICell, IRow[ICell]]()
 	resp.SetError(fmt.Errorf("error test!"))
 
@@ -79,6 +84,7 @@ func TestSharedServerResponseRequestErrors(t *testing.T) {
 }
 
 func TestSharedServerResponseRequestStatus(t *testing.T) {
+	logger.LogSetup()
 	resp := NewResponse[ICell, IRow[ICell]]()
 	if resp.GetStatus() != http.StatusOK {
 		t.Errorf("default status not set")
@@ -91,6 +97,7 @@ func TestSharedServerResponseRequestStatus(t *testing.T) {
 
 }
 func TestSharedServerResponseRequestDataAge(t *testing.T) {
+	logger.LogSetup()
 	resp := NewResponse[ICell, IRow[ICell]]()
 	now := time.Now().UTC()
 	min := now.AddDate(-1, 0, 0).UTC()
@@ -118,6 +125,7 @@ func TestSharedServerResponseRequestDataAge(t *testing.T) {
 }
 
 func TestSharedServerResponseRequestDuration(t *testing.T) {
+	logger.LogSetup()
 	resp := NewResponse[ICell, IRow[ICell]]()
 	resp.SetStart()
 	resp.SetEnd()
@@ -130,6 +138,7 @@ func TestSharedServerResponseRequestDuration(t *testing.T) {
 
 }
 func TestSharedServerResponseRequestStart(t *testing.T) {
+	logger.LogSetup()
 	now := time.Now().UTC()
 	resp := NewResponse[*Cell, *Row[*Cell]]()
 	resp.SetStart()
@@ -141,6 +150,7 @@ func TestSharedServerResponseRequestStart(t *testing.T) {
 }
 
 func TestSharedServerResponseRequestEnd(t *testing.T) {
+	logger.LogSetup()
 	now := time.Now().UTC()
 	resp := NewResponse[*Cell, *Row[*Cell]]()
 	resp.SetEnd()

--- a/shared/server/server_test.go
+++ b/shared/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"opg-reports/internal/testhelpers"
 	"opg-reports/shared/data"
 	"opg-reports/shared/files"
+	"opg-reports/shared/logger"
 	"opg-reports/shared/server/response"
 	"os"
 	"testing"
@@ -26,6 +27,7 @@ func (i *tEntry) Valid() bool {
 	return true
 }
 func TestSharedServerApi(t *testing.T) {
+	logger.LogSetup()
 	td := os.TempDir()
 	tDir, _ := os.MkdirTemp(td, "server-test-*")
 	defer os.RemoveAll(tDir)
@@ -50,6 +52,7 @@ func TestSharedServerApi(t *testing.T) {
 }
 
 func TestSharedServerApiGetParams(t *testing.T) {
+	logger.LogSetup()
 	td := os.TempDir()
 	tDir, _ := os.MkdirTemp(td, "server-test-*")
 	defer os.RemoveAll(tDir)


### PR DESCRIPTION
Allow filtering of aws cost data by account unit (`unit`) and account environment (`environment`) via GET parameters.

- Clean up aws monhtly cost api files - splitting some functions to new files
- Rename methods on the aws cost api for clarity
- Add filter capability to the aws monthyl costs end point
- Add filters to the response metadata
- Add call to log setup to all tests to allow log level changes to work